### PR TITLE
Oof

### DIFF
--- a/src/pluralkit/bot/help.py
+++ b/src/pluralkit/bot/help.py
@@ -3,7 +3,7 @@ system_commands = """
 Commands for adding, removing, editing, and linking systems, as well as querying fronter and front history.
 ```
 pk;system [system]
-pk;system new [system name
+pk;system new [system name]
 pk;system rename [new name]
 pk;system description [new description]
 pk;system avatar [new avatar url]


### PR DESCRIPTION
Added the missing closing square bracket to `pk;system new [system name` on the help output for `pk;system new`