### PR TITLE
Corrects aiohttp error discord-py throws.

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,5 @@
 aiodns
-aiohttp
+aiohttp==3.3.0
 asyncpg
 dateparser
 https://github.com/Rapptz/discord.py/archive/860d6a9ace8248dfeec18b8b159e7b757d9f56bb.zip#egg=discord.py


### PR DESCRIPTION
Error when using latest aiohttp:
```Successfully built aiohttp asyncpg discord.py humanize uvloop ciso8601 pycares multidict yarl idna-ssl regex tzlocal websockets numpy cffi pycparser
discord-py 1.0.0a0 has requirement aiohttp<3.5.0,>=3.3.0, but you'll have aiohttp 3.5.4 which is incompatible.
```

Correction is to set version used to 3.5.0.