### PR TITLE
Updated help.py and added ellipsis truncation for system list member descriptions

### DIFF
--- a/src/pluralkit/bot/commands/system_commands.py
+++ b/src/pluralkit/bot/commands/system_commands.py
@@ -136,13 +136,13 @@ async def system_timezone(ctx: CommandContext):
 
     if not timezone_name:
         raise CommandError("Time zone for city '{}' not found. This should never happen.".format(data[0]["display_name"]))
-    
+
     # This should hopefully result in a valid time zone name
     # (if not, something went wrong)
     tz = await system.set_time_zone(ctx.conn, timezone_name)
     offset = tz.utcoffset(datetime.utcnow())
     offset_str = "UTC{:+02d}:{:02d}".format(int(offset.total_seconds() // 3600), int(offset.total_seconds() // 60 % 60))
-    
+
     await ctx.reply_ok("System time zone set to {} ({}, {}).\n*Data from OpenStreetMap, queried using Nominatim.*".format(tz.tzname(datetime.utcnow()), offset_str, tz.zone))
 
 
@@ -218,7 +218,7 @@ async def account_link(ctx: CommandContext):
 
 async def account_unlink(ctx: CommandContext):
     system = await ctx.ensure_system()
-    
+
     msg = await ctx.reply("Are you sure you want to unlink this account from your system?")
     if not await ctx.confirm_react(ctx.message.author, msg):
         raise CommandError("Account unlink cancelled.")
@@ -363,9 +363,9 @@ async def system_frontpercent(ctx: CommandContext, system: System):
 
 async def system_list(ctx: CommandContext, system: System):
     all_members = sorted(await system.get_members(ctx.conn), key=lambda m: m.name.lower())
-    page_size = 5
+    page_size = 8
     if len(all_members) <= page_size:
-        # If we have less than 10 members, don't bother paginating
+        # If we have less than 8 members, don't bother paginating
         await ctx.reply(embed=embeds.member_list(system, all_members, 0, page_size))
     else:
         current_page = 0
@@ -388,13 +388,13 @@ async def system_list(ctx: CommandContext, system: System):
             try:
                 reaction, _ = await ctx.client.wait_for("reaction_add", timeout=5*60, check=check)
             except asyncio.TimeoutError:
-                return 
+                return
 
             if reaction.emoji == "\u2B05":
                 current_page = (current_page - 1) % page_count
             elif reaction.emoji == "\u27A1":
                 current_page = (current_page + 1) % page_count
-            
+
             # If we can, remove the original reaction from the member
             # Don't bother checking permission if we're in DMs (wouldn't work anyway)
             if ctx.message.guild:

--- a/src/pluralkit/bot/embeds.py
+++ b/src/pluralkit/bot/embeds.py
@@ -25,6 +25,12 @@ def truncate_description(s: str) -> str:
     return s[:2048]
 
 
+def truncate_description_list(s: str) -> str:
+    if len(s) > 512:
+        return s[:512-45] + "..."
+    return s
+
+
 def truncate_title(s: str) -> str:
     return s[:256]
 
@@ -238,7 +244,9 @@ def member_list(system: System, all_members: List[Member], current_page: int, pa
             member_description += "**Birthday:** {}\n".format(member.birthday_string())
         if member.pronouns:
             member_description += "**Pronouns:** {}\n".format(member.pronouns)
-        if member.description:
+        if len(member.description) > 512:
+            member_description += "\n" + truncate_description_list(member.description) + "\n" + "Type `pk;member {}` for full description.".format(member.hid)
+        else:
             member_description += "\n" + member.description
 
         embed.add_field(name=member.name, value=truncate_field_body(member_description) or "\u200B", inline=False)

--- a/src/pluralkit/bot/help.py
+++ b/src/pluralkit/bot/help.py
@@ -1,12 +1,12 @@
 system_commands = """
-**System commands**
+__**System commands**__
 Commands for adding, removing, editing, and linking systems, as well as querying fronter and front history.
 ```
 pk;system [system]
 pk;system new [system name]
 pk;system rename [new name]
 pk;system description [new description]
-pk;system avatar [new avatar url]
+pk;system avatar [new avatar URL]
 pk;system tag [new system tag]
 pk;system timezone [city/town]
 pk;system delete
@@ -14,21 +14,20 @@ pk;system [system] fronter
 pk;system [system] fronthistory
 pk;system [system] frontpercent
 pk;system [system] list
-pk;link <other account>
+pk;link <@other account>
 pk;unlink
 ```
 """.strip()
 
 member_commands = """
-**Member commands**
+__**Member commands**__
 Commands for adding, removing, and modifying members, as well as adding, removing and moving switches.
 ```
 pk;member new <member name>
 pk;member <member>
 pk;member <member> rename <new name>
 pk;member <member> description [new description]
-pk;member <member> avatar [new avatar url]
-(Please bear in mind that your avatar image has to have 1 dimension 1024 pixels or less, i.e. 1024x2000 or 2500x1024, otherwise it will not stick!)
+pk;member <member> avatar [new avatar URL/@username]
 pk;member <member> proxy [example match]
 pk;member <member> pronouns [new pronouns]
 pk;member <member> color [new color]
@@ -39,10 +38,11 @@ pk;switch move <time to move>
 pk;switch out
 pk;switch delete
 ```
+**Please bear in mind that your avatar image has to have 1 dimension 1024 pixels or less, i.e. 1024x2000 or 2500x1024, and be 1 MB or less in size otherwise it will not stick!**
 """.strip()
 
 help_commands = """
-**Help commands**
+__**Help commands**__
 ```
 pk;help
 pk;help commands
@@ -52,10 +52,10 @@ pk;help proxy
 ```""".strip()
 
 other_commands = """
-**Other commands**
+__**Other commands**__
 ```
 pk;log <log channel>
-pk;message <message id>
+pk;message <message ID>
 pk;invite
 pk;import
 pk;export
@@ -65,9 +65,9 @@ pk;token refresh
 """.strip()
 
 command_notes = """
-**Command notes**
-Parameters in <angle brackets> are required, [square brackets] are optional .
-Member references can be a member ID or, for your own system, a member name.
+__**Command notes**__
+Parameters in <angle brackets> are required, [square brackets] are optional. **Do not include the brackets themselves when using the command.**
+Member references can be a member ID or, for your own system, a member name. **If a member name contains spaces, it must be wrapped in "quotation marks" when being referenced (but not during creation).**
 Leaving an optional parameter blank will often clear the relevant value.
 """.strip()
 
@@ -77,16 +77,16 @@ all_commands = """
 {}
 {}
 {}
-""".strip().format(system_commands, member_commands, help_commands, other_commands, command_notes)
+""".strip().format(system_commands, member_commands + "\n", help_commands, other_commands, command_notes)
 
 proxy_guide = """
-**Proxying**
+__**Proxying**__
 Proxying through PluralKit lets system members have their own faux-account with their name and avatar.
-You'll type a message from your account in *proxy tags*, and PluralKit will recognize those tags and repost the message with the proper details.
+You'll type a message from your account in *proxy tags*, and PluralKit will recognize those tags and repost the message with the proper details, with the minor caveat of having the **[BOT]** icon next to the name (this is a Discord limitation and cannot be circumvented).
 
 To set up a member's proxy tag, use the `pk;member <name> proxy [example match]` command.
 
-You'll need to give the bot an "example match". Imagine you're proxying the word "text", and add that to the end.
+You'll need to give the bot an "example match" containing the word `text`. Imagine you're proxying the word "text", and add that to the end of the command.
 For example: `pk;member John proxy [text]`. That will set the member John up to use square brackets as proxy tags.
 Now saying something like `[hello world]` will proxy the text "hello world" with John's name and avatar.
 You can also use other symbols, letters, numbers, et cetera, as prefixes, suffixes, or both. `J:text`, `$text` and `text]` are also examples of valid example matches.
@@ -96,21 +96,36 @@ You can delete a proxied message by reacting to it with the :x: emoji from the s
 """.strip()
 
 root = """
-**PluralKit**
+__**PluralKit**__
 PluralKit is a bot designed for plural communities on Discord. It allows you to register systems, maintain system information, set up message proxying, log switches, and more.
 
-**Getting started**
+**Who's this for? What are systems?**
+Put simply, a system is a person that shares their body with at least 1 other sentient "self". This may be a result of having a dissociative disorder like DID/OSDD or a practice known as Tulpamancy, but people that aren't tulpamancers or undiagnosed and have headmates are also systems.
+
+**Why are people's names saying [BOT] next to them? What's going on?**
+These people are not actually bots, this is simply a caveat to the message proxying feature of PluralKit.
+Type `pk;help proxy` for an in-depth explanation.
+
+__**Getting started**__
 To get started using the bot, try running the following commands.
 **1**. `pk;system new` - Create a system if you haven't already
 **2**. `pk;member add John` - Add a new member to your system
 **3**. `pk;member John proxy [text]` - Set up square brackets as proxy tags
 **4**. You're done!
 
-**More information**
-For a full list of commands, type `pk;help commands`.
-For a more in-depth explanation of proxying, type `pk;help proxy`.
-If you're an existing user of the Tupperware proxy bot, type `pk;import` to import your data from there.
+**5**. Optionally, you may set an avatar from the URL of an image with:
+`pk;member John avatar [link to image]`
+Type `pk;help member` for more information.
 
-**Support server**
+**Useful tip:**
+You can delete a proxied message by reacting to it with :x: (if you sent it!).
+
+
+__**More information**__
+For a full list of commands, type `pk;help commands`.
+For a more in-depth explanation of message proxying, type `pk;help proxy`.
+If you're an existing user of the Tupperbox proxy bot, type `pk;import` to import your data from there.
+
+__**Support server**__
 We also have a Discord server for support, discussion, suggestions, announcements, etc: <https://discord.gg/PczBt78>
 """.strip()


### PR DESCRIPTION
Added more info to help.py for a bunch of command outputs and fixed some stuff to clean it up. 
Added ellipsis truncation to the pk;system list member descriptions and changed the pagination limit from 5 to 8 members, leaving buffer for the message "Type `pk,member <hid>` for full description.". 