### PR TITLE
Added API endpoint, changed API token sending, fixed stuff

### DIFF
--- a/src/pluralkit/bot/commands/__init__.py
+++ b/src/pluralkit/bot/commands/__init__.py
@@ -201,6 +201,8 @@ async def command_root(ctx: CommandContext):
         await misc_commands.pkfire(ctx)
     elif ctx.match("thunder"):
         await misc_commands.pkthunder(ctx)
+    elif ctx.match("freeze"):
+        await misc_commands.pkfreeze(ctx)
     elif ctx.match("starstorm"):
         await misc_commands.pkstarstorm(ctx)
     else:

--- a/src/pluralkit/bot/commands/api_commands.py
+++ b/src/pluralkit/bot/commands/api_commands.py
@@ -18,14 +18,17 @@ async def token_get(ctx: CommandContext):
     else:
         token = await system.refresh_token(ctx.conn)
 
-    token_message = "Here's your API token: \n**`{}`**\n{}".format(token, disclaimer)
-    return await ctx.reply_ok_dm(token_message)
-
+    token_message = "{}\n\u2705 Here's your API token:".format(disclaimer)
+    if token:
+        await ctx.message.author.send(token_message)
+        await ctx.message.author.send(token)
+    return
 
 async def token_refresh(ctx: CommandContext):
     system = await ctx.ensure_system()
 
     token = await system.refresh_token(ctx.conn)
-    token_message = "Your previous API token has been invalidated. You will need to change it anywhere it's currently used.\nHere's your new API token:\n**`{}`**\n{}".format(
-        token, disclaimer)
-    return await ctx.reply_ok_dm(token_message)
+    token_message = "Your previous API token has been invalidated. You will need to change it anywhere it's currently used.\n{}\n\u2705 Here's your new API token:".format(disclaimer)
+    if token:
+        await ctx.message.author.send(token_message)
+        await ctx.message.author.send(token)

--- a/src/pluralkit/bot/commands/misc_commands.py
+++ b/src/pluralkit/bot/commands/misc_commands.py
@@ -16,7 +16,7 @@ async def help_root(ctx: CommandContext):
     elif ctx.match("system"):
         await ctx.reply(help.system_commands, embed=help_footer_embed())
     elif ctx.match("member"):
-        await ctx.reply(help.member_commands, embed=help_footer_embed())
+        await ctx.reply(help.member_commands + "\n\n" + help.command_notes, embed=help_footer_embed())
     else:
         await ctx.reply(help.root, embed=help_footer_embed())
 
@@ -94,7 +94,7 @@ async def export(ctx: CommandContext):
     await working_msg.delete()
 
     f = io.BytesIO(json.dumps(data).encode("utf-8"))
-    await ctx.message.channel.send(content="Export successful! File sent in your DMs.")
+    await ctx.reply_ok("DM'd!")
     await ctx.message.author.send(content="Here you go!", file=discord.File(fp=f, filename="pluralkit_system.json"))
 
 
@@ -119,6 +119,9 @@ async def pkfire(ctx: CommandContext):
 
 async def pkthunder(ctx: CommandContext):
     await ctx.message.channel.send("*A giant ball of lightning is conjured and fired directly at your opponent, vanquishing them.*")
+
+async def pkfreeze(ctx: CommandContext):
+    await ctx.message.channel.send("*A giant crystal ball of ice is charged and hurled toward your opponent, bursting open and freezing them solid on contact.*")
 
 async def pkstarstorm(ctx: CommandContext):
     await ctx.message.channel.send("*Vibrant colours burst forth from the sky as meteors rain down upon your opponent.*")


### PR DESCRIPTION
Added an API endpoint (/s/<system hid>/fronters) to GET member profiles of current fronters. 

Added the "Command notes" help section onto the end of member help output (i.e. <> required, [] optional, etc). 

Made API token string send in a new message, making copying and pasting easier for mobile users. 