### PR TITLE
Add frontpercent command aliases

### DIFF
--- a/src/pluralkit/bot/commands/system_commands.py
+++ b/src/pluralkit/bot/commands/system_commands.py
@@ -34,7 +34,7 @@ async def system_root(ctx: CommandContext):
         await system_fronter(ctx, await ctx.ensure_system())
     elif ctx.match("fronthistory"):
         await system_fronthistory(ctx, await ctx.ensure_system())
-    elif ctx.match("frontpercent") or ctx.match("frontbreakdown") or ctx.match("frontpercentage"):
+    elif ctx.match("frontpercent") or ctx.match("frontbreakdown") or ctx.match("frontpercentage") or ctx.match("front%") or ctx.match("fp"):
         await system_frontpercent(ctx, await ctx.ensure_system())
     elif ctx.match("timezone") or ctx.match("tz"):
         await system_timezone(ctx)

--- a/src/pluralkit/bot/help.json
+++ b/src/pluralkit/bot/help.json
@@ -78,12 +78,12 @@
                 },
                 {
                     "name": "frontpercent",
-                    "aliases": ["system frontbreakdown", "system frontpercentage"],
-                    "usage": "system [id] fronthistory [timeframe]",
+                    "aliases": ["system frontbreakdown", "system frontpercentage", "system front%", "system fp"],
+                    "usage": "system [id] frontpercent [timeframe]",
                     "category": "System",
                     "description": "Shows the aggregated front history of a system within a given time frame.",
                     "longdesc": "Percentages may add up to over 100% when multiple members cofront. Time frame will default to 1 month.",
-                    "examples": ["system fronthistory 1 month", "system fronthistory 2 weeks", "system @Foo#1234 fronthistory 4 days"]
+                    "examples": ["system frontpercent 1 month", "system frontpercent 2 weeks", "system @Foo#1234 frontpercent 4 days"]
                 },
                 {
                     "name": "list",


### PR DESCRIPTION
Added:
`pk;system front%`
`pk;system fp`

Also fixed the help file which had the entire `frontpercent` command listed as `fronthistory` again. 