### PR TITLE
Add yet more command aliases

### DIFF
--- a/src/pluralkit/bot/commands/switch_commands.py
+++ b/src/pluralkit/bot/commands/switch_commands.py
@@ -5,14 +5,16 @@ import dateparser
 import pytz
 
 from pluralkit.bot.commands import *
+from pluralkit.bot.commands.system_commands import system_fronthistory
 from pluralkit.member import Member
 from pluralkit.utils import display_relative
 
 
 async def switch_root(ctx: CommandContext):
     if not ctx.has_next():
-        raise CommandError("You must use a subcommand. For a list of subcommands, type `pk;help member`.")
-
+        # We could raise an error here, but we display the system front history instead as a shortcut
+        #raise CommandError("You must use a subcommand. For a list of subcommands, type `pk;help member`.")
+        await system_fronthistory(ctx, await ctx.ensure_system())
     if ctx.match("out"):
         await switch_out(ctx)
     elif ctx.match("move"):

--- a/src/pluralkit/bot/commands/system_commands.py
+++ b/src/pluralkit/bot/commands/system_commands.py
@@ -244,7 +244,7 @@ async def system_fronthistory(ctx: CommandContext, system: System):
     front_history = await pluralkit.utils.get_front_history(ctx.conn, system.id, count=10)
 
     if not front_history:
-        raise CommandError("You have no logged switches. Use `pk;switch´ to start logging.")
+        raise CommandError("You have no logged switches. Use `pk;switch [member] [extra members...]` to start logging.")
 
     for i, (timestamp, members) in enumerate(front_history):
         # Special case when no one's fronting

--- a/src/pluralkit/bot/commands/system_commands.py
+++ b/src/pluralkit/bot/commands/system_commands.py
@@ -32,7 +32,7 @@ async def system_root(ctx: CommandContext):
         await system_delete(ctx)
     elif ctx.match("front") or ctx.match("fronter") or ctx.match("fronters"):
         await system_fronter(ctx, await ctx.ensure_system())
-    elif ctx.match("fronthistory"):
+    elif ctx.match("fronthistory") or ctx.match("fh") or ctx.match("history") or ctx.match("switches"):
         await system_fronthistory(ctx, await ctx.ensure_system())
     elif ctx.match("frontpercent") or ctx.match("frontbreakdown") or ctx.match("frontpercentage") or ctx.match("front%") or ctx.match("fp"):
         await system_frontpercent(ctx, await ctx.ensure_system())

--- a/src/pluralkit/bot/help.json
+++ b/src/pluralkit/bot/help.json
@@ -72,6 +72,7 @@
                 },
                 {
                     "name": "fronthistory",
+                    "aliases": ["system fh", "system history", "system switches"],
                     "usage": "system [id] fronthistory",
                     "category": "System",
                     "description": "Shows the last 10 switches of a system."

--- a/src/pluralkit/bot/help.json
+++ b/src/pluralkit/bot/help.json
@@ -201,11 +201,11 @@
         {
             "name": "switch",
             "aliases": ["sw"],
-            "usage": "switch <member> [member...]",
+            "usage": "switch [member] [extra members...]",
             "category": "Switching",
-            "description": "Registers a switch with the given members.",
-            "longdesc": "You may specify multiple members to indicate cofronting.",
-            "examples": ["switch Jack", "switch Jack Jill"],
+            "description": "Registers a switch with the given members, or displays a list of logged switches if no members are given.",
+            "longdesc": "You may specify multiple members to indicate cofronting. Shows the last 10 switches of a system if no members are given.",
+            "examples": ["switch Jack", "switch Jack Jill", "switch"],
             "subcommands": [
                 {
                     "name": "move",


### PR DESCRIPTION
- Add aliases for `pk;system fronthistory`:
  - `pk;system fh`
  - `pk;system history`
  - `pk;system switches`  
- Display a list of the 10 most recent switches of a system when `pk;switch` is issued without any members (i.e. when you just type `pk;switch` or `pk;sw`) instead of raising an error