### PR TITLE
Delete bot posts by reaction

### DIFF
--- a/src/pluralkit/bot/commands/__init__.py
+++ b/src/pluralkit/bot/commands/__init__.py
@@ -164,6 +164,16 @@ class CommandContext:
         except asyncio.TimeoutError:
             raise CommandError("Timed out - try again.")
 
+    async def delete_by_react(self, user: Union[discord.Member, discord.User], message: discord.Message):
+        try:
+            await message.add_reaction("🗑")  # Wastebasket
+            reaction, _ = await self.client.wait_for("reaction_add", check=lambda r, u: u.id == user.id and r.emoji in ["🗑"], 
+                                                     timeout=60 * 10) # 10 minute timeout
+            return reaction.emoji == "🗑"
+        except asyncio.TimeoutError:
+            # Delete the reaction if the user doesn't react within the timeout period
+            await message.remove_reaction("🗑", self.client.user)
+
 
 import pluralkit.bot.commands.api_commands
 import pluralkit.bot.commands.import_commands

--- a/src/pluralkit/bot/commands/member_commands.py
+++ b/src/pluralkit/bot/commands/member_commands.py
@@ -7,8 +7,6 @@ from pluralkit.errors import PluralKitError
 async def member_root(ctx: CommandContext):
     if ctx.match("new") or ctx.match("create") or ctx.match("add") or ctx.match("register"):
         await new_member(ctx)
-    elif ctx.match("set"):
-        await member_set(ctx)
     # TODO "pk;member list"
     elif not ctx.has_next():
         raise CommandError("Must pass a subcommand. For a list of subcommands, type `pk;help member`.")
@@ -79,11 +77,6 @@ async def new_member(ctx: CommandContext):
 
     await ctx.reply_ok(
         "Member \"{}\" (`{}`) registered! Type `pk;help member` for a list of commands to edit this member.".format(new_name, member.hid))
-
-
-async def member_set(ctx: CommandContext):
-    raise CommandError(
-        "`pk;member set` has been retired. Please use the new member modifying commands. Type `pk;help member` for a list.")
 
 
 async def member_name(ctx: CommandContext, member: Member):

--- a/src/pluralkit/bot/commands/member_commands.py
+++ b/src/pluralkit/bot/commands/member_commands.py
@@ -52,7 +52,12 @@ async def member_info(ctx: CommandContext, member: Member):
     msg = await ctx.reply(embed=await pluralkit.bot.embeds.member_card(ctx.conn, member))
     if await ctx.delete_by_react(ctx.message.author, msg):
         await msg.delete()
-        await ctx.message.delete()
+        try:
+            await ctx.message.delete()
+        except discord.Forbidden:
+            # This will fail if we don't have Manage messages, just silently fail tbh
+            # The user can delete their own command if they want
+            pass
 
 
 async def new_member(ctx: CommandContext):

--- a/src/pluralkit/bot/commands/member_commands.py
+++ b/src/pluralkit/bot/commands/member_commands.py
@@ -51,7 +51,10 @@ async def specific_member_root(ctx: CommandContext):
 
 
 async def member_info(ctx: CommandContext, member: Member):
-    await ctx.reply(embed=await pluralkit.bot.embeds.member_card(ctx.conn, member))
+    msg = await ctx.reply(embed=await pluralkit.bot.embeds.member_card(ctx.conn, member))
+    if await ctx.delete_by_react(ctx.message.author, msg):
+        await msg.delete()
+        await ctx.message.delete()
 
 
 async def new_member(ctx: CommandContext):

--- a/src/pluralkit/bot/commands/message_commands.py
+++ b/src/pluralkit/bot/commands/message_commands.py
@@ -15,4 +15,7 @@ async def message_info(ctx: CommandContext):
         raise CommandError(
             "Message with ID '{}' not found. Are you sure it's a message proxied by PluralKit?".format(mid))
 
-    await ctx.reply(embed=await embeds.message_card(ctx.client, message))
+    msg = await ctx.reply(embed=await embeds.message_card(ctx.client, message))
+    if await ctx.delete_by_react(ctx.message.author, msg):
+        await msg.delete()
+        await ctx.message.delete()

--- a/src/pluralkit/bot/commands/message_commands.py
+++ b/src/pluralkit/bot/commands/message_commands.py
@@ -18,4 +18,7 @@ async def message_info(ctx: CommandContext):
     msg = await ctx.reply(embed=await embeds.message_card(ctx.client, message))
     if await ctx.delete_by_react(ctx.message.author, msg):
         await msg.delete()
-        await ctx.message.delete()
+        try:
+            await ctx.message.delete()
+        except discord.Forbidden:
+            pass

--- a/src/pluralkit/bot/commands/system_commands.py
+++ b/src/pluralkit/bot/commands/system_commands.py
@@ -38,8 +38,6 @@ async def system_root(ctx: CommandContext):
         await system_frontpercent(ctx, await ctx.ensure_system())
     elif ctx.match("timezone") or ctx.match("tz"):
         await system_timezone(ctx)
-    elif ctx.match("set"):
-        await system_set(ctx)
     elif ctx.match("list") or ctx.match("members"):
         await system_list(ctx, await ctx.ensure_system())
     elif not ctx.has_next():
@@ -89,11 +87,6 @@ async def system_new(ctx: CommandContext):
         raise CommandError(e.message)
 
     await ctx.reply_ok("System registered! To begin adding members, use `pk;member new <name>`.")
-
-
-async def system_set(ctx: CommandContext):
-    raise CommandError(
-        "`pk;system set` has been retired. Please use the new system modifying commands. Type `pk;help system` for a list.")
 
 
 async def system_name(ctx: CommandContext):

--- a/src/pluralkit/bot/commands/system_commands.py
+++ b/src/pluralkit/bot/commands/system_commands.py
@@ -74,8 +74,11 @@ async def specified_system_root(ctx: CommandContext):
 
 async def system_info(ctx: CommandContext, system: System):
     this_system = await ctx.get_system()
-    await ctx.reply(embed=await pluralkit.bot.embeds.system_card(ctx.conn, ctx.client, system, this_system and this_system.id == system.id))
+    msg = await ctx.reply(embed=await pluralkit.bot.embeds.system_card(ctx.conn, ctx.client, system, this_system and this_system.id == system.id))
 
+    if await ctx.delete_by_react(ctx.message.author, msg):
+        await msg.delete()
+        await ctx.message.delete()
 
 async def system_new(ctx: CommandContext):
     new_name = ctx.remaining() or None
@@ -265,7 +268,11 @@ async def system_fronthistory(ctx: CommandContext, system: System):
 
     embed = embeds.status("\n".join(lines) or "(none)")
     embed.title = "Past switches"
-    await ctx.reply(embed=embed)
+    msg = await ctx.reply(embed=embed)
+
+    if await ctx.delete_by_react(ctx.message.author, msg):
+        await msg.delete()
+        await ctx.message.delete()
 
 
 async def system_delete(ctx: CommandContext):
@@ -362,7 +369,11 @@ async def system_frontpercent(ctx: CommandContext, system: System):
 
     embed.set_footer(text="Since {} ({} ago)".format(ctx.format_time(span_start),
                                                      display_relative(span_start)))
-    await ctx.reply(embed=embed)
+    msg = await ctx.reply(embed=embed)
+
+    if await ctx.delete_by_react(ctx.message.author, msg):
+        await msg.delete()
+        await ctx.message.delete()
 
 async def system_list(ctx: CommandContext, system: System):
     # TODO: refactor this
@@ -372,7 +383,10 @@ async def system_list(ctx: CommandContext, system: System):
         page_size = 8
         if len(all_members) <= page_size:
             # If we have less than 8 members, don't bother paginating
-            await ctx.reply(embed=embeds.member_list_full(system, all_members, 0, page_size))
+            msg = await ctx.reply(embed=embeds.member_list_full(system, all_members, 0, page_size))
+            if await ctx.delete_by_react(ctx.message.author, msg):
+                await msg.delete()
+                await ctx.message.delete()
         else:
             current_page = 0
             msg: discord.Message = None
@@ -385,6 +399,9 @@ async def system_list(ctx: CommandContext, system: System):
                     msg = await ctx.reply(embed=embed)
                     await msg.add_reaction("\u2B05")
                     await msg.add_reaction("\u27A1")
+                    if await ctx.delete_by_react(ctx.message.author, msg):
+                        await msg.delete()
+                        await ctx.message.delete()
                 else:
                     await msg.edit(embed=embed)
 
@@ -413,7 +430,10 @@ async def system_list(ctx: CommandContext, system: System):
         page_size = 25
         if len(all_members) <= page_size:
             # If we have less than 25 members, don't bother paginating
-            await ctx.reply(embed=embeds.member_list_short(system, all_members, 0, page_size))
+            msg = await ctx.reply(embed=embeds.member_list_short(system, all_members, 0, page_size))
+            if await ctx.delete_by_react(ctx.message.author, msg):
+                await msg.delete()
+                await ctx.message.delete()
         else:
             current_page = 0
             msg: discord.Message = None
@@ -425,6 +445,9 @@ async def system_list(ctx: CommandContext, system: System):
                     msg = await ctx.reply(embed=embed)
                     await msg.add_reaction("\u2B05")
                     await msg.add_reaction("\u27A1")
+                    if await ctx.delete_by_react(ctx.message.author, msg):
+                        await msg.delete()
+                        await ctx.message.delete()
                 else:
                     await msg.edit(embed=embed)
 

--- a/src/pluralkit/bot/commands/system_commands.py
+++ b/src/pluralkit/bot/commands/system_commands.py
@@ -76,7 +76,10 @@ async def system_info(ctx: CommandContext, system: System):
 
     if await ctx.delete_by_react(ctx.message.author, msg):
         await msg.delete()
-        await ctx.message.delete()
+        try:
+            await ctx.message.delete()
+        except discord.Forbidden:
+            pass
 
 async def system_new(ctx: CommandContext):
     new_name = ctx.remaining() or None
@@ -265,7 +268,10 @@ async def system_fronthistory(ctx: CommandContext, system: System):
 
     if await ctx.delete_by_react(ctx.message.author, msg):
         await msg.delete()
-        await ctx.message.delete()
+        try:
+            await ctx.message.delete()
+        except discord.Forbidden:
+            pass
 
 
 async def system_delete(ctx: CommandContext):
@@ -366,7 +372,10 @@ async def system_frontpercent(ctx: CommandContext, system: System):
 
     if await ctx.delete_by_react(ctx.message.author, msg):
         await msg.delete()
-        await ctx.message.delete()
+        try:
+            await ctx.message.delete()
+        except discord.Forbidden:
+            pass
 
 async def system_list(ctx: CommandContext, system: System):
     # TODO: refactor this
@@ -379,7 +388,10 @@ async def system_list(ctx: CommandContext, system: System):
             msg = await ctx.reply(embed=embeds.member_list_full(system, all_members, 0, page_size))
             if await ctx.delete_by_react(ctx.message.author, msg):
                 await msg.delete()
-                await ctx.message.delete()
+                try:
+                    await ctx.message.delete()
+                except discord.Forbidden:
+                    pass
         else:
             current_page = 0
             msg: discord.Message = None
@@ -394,7 +406,10 @@ async def system_list(ctx: CommandContext, system: System):
                     await msg.add_reaction("\u27A1")
                     if await ctx.delete_by_react(ctx.message.author, msg):
                         await msg.delete()
-                        await ctx.message.delete()
+                        try:
+                            await ctx.message.delete()
+                        except discord.Forbidden:
+                            pass
                 else:
                     await msg.edit(embed=embed)
 
@@ -426,7 +441,10 @@ async def system_list(ctx: CommandContext, system: System):
             msg = await ctx.reply(embed=embeds.member_list_short(system, all_members, 0, page_size))
             if await ctx.delete_by_react(ctx.message.author, msg):
                 await msg.delete()
-                await ctx.message.delete()
+                try:
+                    await ctx.message.delete()
+                except discord.Forbidden:
+                    pass
         else:
             current_page = 0
             msg: discord.Message = None
@@ -440,7 +458,10 @@ async def system_list(ctx: CommandContext, system: System):
                     await msg.add_reaction("\u27A1")
                     if await ctx.delete_by_react(ctx.message.author, msg):
                         await msg.delete()
-                        await ctx.message.delete()
+                        try:
+                            await ctx.message.delete()
+                        except discord.Forbidden:
+                            pass
                 else:
                     await msg.edit(embed=embed)
 


### PR DESCRIPTION
- Enables users to delete the posts the bot makes by reaction
  - When PluralKit posts a large embed like a system card, member card or member list (essentially any embed), they will also react with 🗑 and if the user clicks it, the embed and the original message with the command in it is deleted from the channel. 
  - If the bot doesn't have the `Manage Messages` permission, then it silently fails, the user can then delete their own message if they want