### PR TITLE
Return member after create/edit

### DIFF
--- a/PluralKit.API/Controllers/MemberController.cs
+++ b/PluralKit.API/Controllers/MemberController.cs
@@ -66,7 +66,7 @@ namespace PluralKit.API.Controllers
             member.Suffix = newMember.Suffix;
             await _members.Save(member);
 
-            return Ok();
+            return Ok(member);
         }
 
         [HttpPatch("{hid}")]
@@ -107,7 +107,7 @@ namespace PluralKit.API.Controllers
             member.Suffix = newMember.Suffix;
             await _members.Save(member);
 
-            return Ok();
+            return Ok(member);
         }
     }
 }


### PR DESCRIPTION
Changing the POST and PATCH routes to return the member that's been created/edited, similar to how it worked before. Makes it easier to compare changes and get a newly created member's ID