### PR TITLE
Return original message ID to log channel

### DIFF
--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -53,13 +53,13 @@ namespace PluralKit.Bot {
             return eb.Build();
         }
 
-        public Embed CreateLoggedMessageEmbed(PKSystem system, PKMember member, ulong messageId, IUser sender, string content, IGuildChannel channel) {
+        public Embed CreateLoggedMessageEmbed(PKSystem system, PKMember member, ulong messageId, ulong originalMsgId, IUser sender, string content, IGuildChannel channel) {
             // TODO: pronouns in ?-reacted response using this card
             var timestamp = SnowflakeUtils.FromSnowflake(messageId);
             return new EmbedBuilder()
                 .WithAuthor($"#{channel.Name}: {member.Name}", member.AvatarUrl)
                 .WithDescription(content)
-                .WithFooter($"System ID: {system.Hid} | Member ID: {member.Hid} | Sender: {sender.Username}#{sender.Discriminator} ({sender.Id}) | Message ID: {messageId}")
+                .WithFooter($"System ID: {system.Hid} | Member ID: {member.Hid} | Sender: {sender.Username}#{sender.Discriminator} ({sender.Id}) | Message ID: {messageId} | Original Message ID: {originalMsgId}")
                 .WithTimestamp(timestamp)
                 .Build();
         }

--- a/PluralKit.Bot/Services/LogChannelService.cs
+++ b/PluralKit.Bot/Services/LogChannelService.cs
@@ -6,7 +6,7 @@ using Serilog;
 namespace PluralKit.Bot {
     public class ServerDefinition {
         public ulong Id { get; set; }
-        public ulong? LogChannel { get; set; } 
+        public ulong? LogChannel { get; set; }
     }
 
     public class LogChannelService {
@@ -23,11 +23,11 @@ namespace PluralKit.Bot {
             _logger = logger.ForContext<LogChannelService>();
         }
 
-        public async Task LogMessage(PKSystem system, PKMember member, ulong messageId, IGuildChannel originalChannel, IUser sender, string content) {
+        public async Task LogMessage(PKSystem system, PKMember member, ulong messageId, ulong originalMsgId, IGuildChannel originalChannel, IUser sender, string content) {
             var logChannel = await GetLogChannel(originalChannel.Guild);
             if (logChannel == null) return;
 
-            var embed = _embed.CreateLoggedMessageEmbed(system, member, messageId, sender, content, originalChannel);
+            var embed = _embed.CreateLoggedMessageEmbed(system, member, messageId, originalMsgId, sender, content, originalChannel);
 
             var url = $"https://discordapp.com/channels/{originalChannel.GuildId}/{originalChannel.Id}/{messageId}";
             await logChannel.SendMessageAsync(text: url, embed: embed);
@@ -56,7 +56,7 @@ namespace PluralKit.Bot {
                     "insert into servers (id, log_channel) values (@Id, @LogChannel) on conflict (id) do update set log_channel = @LogChannel",
                     def);
             }
-            
+
             _logger.Information("Set guild {Guild} log channel to {Channel}", guild.Id, newLogChannel?.Id);
         }
     }


### PR DESCRIPTION
- Logs the original (deleted) message's ID in addition to the proxied message's ID to the log channel if configured