### PR TITLE
Confirm before clearing system/member property

### DIFF
--- a/PluralKit.API/Controllers/MemberController.cs
+++ b/PluralKit.API/Controllers/MemberController.cs
@@ -38,6 +38,11 @@ namespace PluralKit.API.Controllers
             if (newMember.Name == null)
             return BadRequest("Member name cannot be null.");
 
+            // Enforce per-system member limit
+            var memberCount = await _members.MemberCount(system);
+            if (memberCount >= Limits.MaxMemberCount)
+                return BadRequest($"Member limit reached ({memberCount} / {Limits.MaxMemberCount}).");
+
             // Explicit bounds checks
             if (newMember.Name != null && newMember.Name.Length > Limits.MaxMemberNameLength)
                 return BadRequest($"Member name too long ({newMember.Name.Length} > {Limits.MaxMemberNameLength}.");

--- a/PluralKit.Bot/CommandSystem/Context.cs
+++ b/PluralKit.Bot/CommandSystem/Context.cs
@@ -86,6 +86,11 @@ namespace PluralKit.Bot.CommandSystem
             {
                 await Reply($"{Emojis.Error} {e.Message}");
             }
+            catch (TimeoutException e)
+            {
+                // Got a complaint the old error was a bit too patronizing. Hopefully this is better?
+                await Reply($"{Emojis.Error} Operation timed out, sorry. Try again, perhaps?");
+            }
         }
 
         public async Task<IUser> MatchUser()

--- a/PluralKit.Bot/Commands/ImportExportCommands.cs
+++ b/PluralKit.Bot/Commands/ImportExportCommands.cs
@@ -103,12 +103,14 @@ namespace PluralKit.Bot.Commands
                     var result = await _dataFiles.ImportSystem(data, ctx.System, ctx.Author.Id);
                     if (!result.Success)
                         await ctx.Reply($"{Emojis.Error} The provided system profile could not be imported. {result.Message}");
-                    else if (ctx.System != null)
+                    else if (ctx.System == null)
                     {
+                        // We didn't have a system prior to importing, so give them the new system's ID
                         await ctx.Reply($"{Emojis.Success} PluralKit has created a system for you based on the given file. Your system ID is `{result.System.Hid}`. Type `pk;system` for more information.");
                     }
                     else
                     {
+                        // We already had a system, so show them what changed
                         await ctx.Reply($"{Emojis.Success} Updated {result.ModifiedNames.Count} members, created {result.AddedNames.Count} members. Type `pk;system list` to check!");
                     }
                 }

--- a/PluralKit.Bot/Commands/ImportExportCommands.cs
+++ b/PluralKit.Bot/Commands/ImportExportCommands.cs
@@ -101,8 +101,9 @@ namespace PluralKit.Bot.Commands
                     // If passed system is null, it'll create a new one
                     // (and that's okay!)
                     var result = await _dataFiles.ImportSystem(data, ctx.System, ctx.Author.Id);
-                    
-                    if (ctx.System != null)
+                    if (!result.Success)
+                        await ctx.Reply($"{Emojis.Error} The provided system profile could not be imported. {result.Message}");
+                    else if (ctx.System != null)
                     {
                         await ctx.Reply($"{Emojis.Success} PluralKit has created a system for you based on the given file. Your system ID is `{result.System.Hid}`. Type `pk;system` for more information.");
                     }

--- a/PluralKit.Bot/Errors.cs
+++ b/PluralKit.Bot/Errors.cs
@@ -22,7 +22,8 @@ namespace PluralKit.Bot {
         public static PKError DescriptionTooLongError(int length) => new PKError($"Description too long ({length}/{Limits.MaxDescriptionLength} characters).");
         public static PKError MemberNameTooLongError(int length) => new PKError($"Member name too long ({length}/{Limits.MaxMemberNameLength} characters).");
         public static PKError MemberPronounsTooLongError(int length) => new PKError($"Member pronouns too long ({length}/{Limits.MaxMemberNameLength} characters).");
-        
+        public static PKError MemberLimitReachedError => new PKError($"System has reached the maximum number of members ({Limits.MaxMemberCount}). Please delete unused members first in order to create new ones.");
+
         public static PKError InvalidColorError(string color) => new PKError($"\"{color.SanitizeMentions()}\" is not a valid color. Color must be in 6-digit RGB hex format (eg. #ff0000).");
         public static PKError BirthdayParseError(string birthday) => new PKError($"\"{birthday.SanitizeMentions()}\" could not be parsed as a valid date. Try a format like \"2016-12-24\" or \"May 3 1996\".");
         public static PKError ProxyMustHaveText => new PKSyntaxError("Example proxy message must contain the string 'text'.");

--- a/PluralKit.Bot/Errors.cs
+++ b/PluralKit.Bot/Errors.cs
@@ -28,7 +28,7 @@ namespace PluralKit.Bot {
         public static PKError BirthdayParseError(string birthday) => new PKError($"\"{birthday.SanitizeMentions()}\" could not be parsed as a valid date. Try a format like \"2016-12-24\" or \"May 3 1996\".");
         public static PKError ProxyMustHaveText => new PKSyntaxError("Example proxy message must contain the string 'text'.");
         public static PKError ProxyMultipleText => new PKSyntaxError("Example proxy message must contain the string 'text' exactly once.");
-        
+
         public static PKError MemberDeleteCancelled => new PKError($"Member deletion cancelled. Stay safe! {Emojis.ThumbsUp}");
         public static PKError AvatarServerError(HttpStatusCode statusCode) => new PKError($"Server responded with status code {(int) statusCode}, are you sure your link is working?");
         public static PKError AvatarFileSizeLimit(long size) => new PKError($"File size too large ({size.Bytes().ToString("#.#")} > {Limits.AvatarFileSizeLimit.Bytes().ToString("#.#")}), try shrinking or compressing the image.");
@@ -36,7 +36,7 @@ namespace PluralKit.Bot {
         public static PKError AvatarDimensionsTooLarge(int width, int height) => new PKError($"Image too large ({width}x{height} > {Limits.AvatarDimensionLimit}x{Limits.AvatarDimensionLimit}), try resizing the image.");
         public static PKError UserHasNoAvatar => new PKError("The given user has no avatar set.");
         public static PKError InvalidUrl(string url) => new PKError($"The given URL is invalid.");
-        
+
         public static PKError AccountAlreadyLinked => new PKError("That account is already linked to your system.");
         public static PKError AccountNotLinked => new PKError("That account isn't linked to your system.");
         public static PKError AccountInOtherSystem(PKSystem system) => new PKError($"The mentioned account is already linked to another system (see `pk;system {system.Hid}`).");
@@ -70,7 +70,7 @@ namespace PluralKit.Bot {
         public static PKError InvalidImportFile => new PKError("Imported data file invalid. Make sure this is a .json file directly exported from PluralKit or Tupperbox.");
         public static PKError ImportCancelled => new PKError("Import cancelled.");
         public static PKError MessageNotFound(ulong id) => new PKError($"Message with ID '{id}' not found. Are you sure it's a message proxied by PluralKit?");
-        
+
         public static PKError DurationParseError(string durationStr) => new PKError($"Could not parse '{durationStr.SanitizeMentions()}' as a valid duration. Try a format such as `30d`, `1d3h` or `20m30s`.");
         public static PKError FrontPercentTimeInFuture => new PKError("Cannot get the front percent between now and a time in the future.");
 
@@ -80,5 +80,7 @@ namespace PluralKit.Bot {
             $"Display name too long ({displayName.Length} > {maxLength} characters). Use a shorter display name, or shorten your system tag.");
         public static PKError ProxyNameTooShort(string name) => new PKError($"The webhook's name, `{name.SanitizeMentions()}`, is shorter than two characters, and thus cannot be proxied. Please change the member name or use a longer system tag.");
         public static PKError ProxyNameTooLong(string name) => new PKError($"The webhook's name, {name.SanitizeMentions()}, is too long ({name.Length} > {Limits.MaxProxyNameLength} characters), and thus cannot be proxied. Please change the member name or use a shorter system tag.");
+
+        public static PKError GenericActionCancelled => new PKError($"Action cancelled. Stay safe! {Emojis.ThumbsUp}");
     }
 }

--- a/PluralKit.Bot/Utils.cs
+++ b/PluralKit.Bot/Utils.cs
@@ -25,8 +25,18 @@ namespace PluralKit.Bot
             throw new ArgumentException($"Invalid color string '{color}'.");
         }
 
+        public static string TrimUrl(this string url)
+        {
+            // Remove <> tags from URL if present (these are used to prevent embed previews in Discord)
+            if (url.StartsWith("<") && url.EndsWith(">")) return url.Substring(1, url.Length - 2);
+            else return url;
+        }
+
         public static async Task VerifyAvatarOrThrow(string url)
         {
+            // Trim "<" and ">" from URL if present
+            url = TrimUrl(url);
+
             // List of MIME types we consider acceptable
             var acceptableMimeTypes = new[]
             {
@@ -70,7 +80,7 @@ namespace PluralKit.Bot
         public static bool HasMentionPrefix(string content, ref int argPos, out ulong mentionId)
         {
             mentionId = 0;
-            
+
             // Roughly ported from Discord.Commands.MessageExtensions.HasMentionPrefix
             if (string.IsNullOrEmpty(content) || content.Length <= 3 || (content[0] != '<' || content[1] != '@'))
                 return false;

--- a/PluralKit.Core/DataFiles.cs
+++ b/PluralKit.Core/DataFiles.cs
@@ -179,9 +179,10 @@ namespace PluralKit.Bot
                 mappedSwitches.Add(mapped);
             }
             // Import switches
-            await _switches.RegisterSwitches(system, mappedSwitches);
+            if (mappedSwitches.Any())
+                await _switches.BulkImportSwitches(system, mappedSwitches);
 
-            _logger.Information("Imported system {System}", system.Id);
+            _logger.Information("Imported system {System}", system.Hid);
             return result;
         }
     }

--- a/PluralKit.Core/DataFiles.cs
+++ b/PluralKit.Core/DataFiles.cs
@@ -121,7 +121,7 @@ namespace PluralKit.Bot
 
             // If creating the unmatched members would put us over the member limit, abort before creating any members
             // new total: # in the system + (# in the file - # in the file that already exist)
-            if (data.Members.Count - dataFileToMemberMapping.Count + existingMembers.Count() >= Limits.MaxMemberCount)
+            if (data.Members.Count - dataFileToMemberMapping.Count + existingMembers.Count() > Limits.MaxMemberCount)
             {
                 result.Success = false;
                 result.Message = $"Import would exceed the maximum number of members ({Limits.MaxMemberCount}).";

--- a/PluralKit.Core/DataFiles.cs
+++ b/PluralKit.Core/DataFiles.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NodaTime;
 using NodaTime.Text;
+using PluralKit.Core;
 using Serilog;
 
 namespace PluralKit.Bot
@@ -70,38 +71,22 @@ namespace PluralKit.Bot
             };
         }
 
-        private async Task<DataFileMember> ExportMember(PKMember member) => new DataFileMember
-        {
-            Id = member.Hid,
-            Name = member.Name,
-            DisplayName = member.DisplayName,
-            Description = member.Description,
-            Birthday = member.Birthday != null ? Formats.DateExportFormat.Format(member.Birthday.Value) : null,
-            Pronouns = member.Pronouns,
-            Color = member.Color,
-            AvatarUrl = member.AvatarUrl,
-            Prefix = member.Prefix,
-            Suffix = member.Suffix,
-            Created = Formats.TimestampExportFormat.Format(member.Created),
-            MessageCount = await _members.MessageCount(member)
-        };
-
-        private async Task<DataFileSwitch> ExportSwitch(PKSwitch sw) => new DataFileSwitch
-        {
-            Members = (await _switches.GetSwitchMembers(sw)).Select(m => m.Hid).ToList(),
-            Timestamp = Formats.TimestampExportFormat.Format(sw.Timestamp)
-        };
-
         public async Task<ImportResult> ImportSystem(DataFileSystem data, PKSystem system, ulong accountId)
         {
             // TODO: make atomic, somehow - we'd need to obtain one IDbConnection and reuse it
             // which probably means refactoring SystemStore.Save and friends etc
-            
-            var result = new ImportResult {AddedNames = new List<string>(), ModifiedNames = new List<string>()};
-            var hidMapping = new Dictionary<string, PKMember>();
+            var result = new ImportResult {
+                AddedNames = new List<string>(),
+                ModifiedNames = new List<string>(),
+                Success = true // Assume success unless indicated otherwise
+            };
+            var dataFileToMemberMapping = new Dictionary<string, PKMember>();
+            var unmappedMembers = new List<DataFileMember>();
 
             // If we don't already have a system to save to, create one
-            if (system == null) system = await _systems.Create(data.Name);
+            if (system == null)
+                system = await _systems.Create(data.Name);
+            result.System = system;
 
             // Apply system info
             system.Name = data.Name;
@@ -110,41 +95,56 @@ namespace PluralKit.Bot
             if (data.AvatarUrl != null) system.AvatarUrl = data.AvatarUrl;
             if (data.TimeZone != null) system.UiTz = data.TimeZone ?? "UTC";
             await _systems.Save(system);
-            
+
             // Make sure to link the sender account, too
             await _systems.Link(system, accountId);
 
-            // Apply members
-            // TODO: parallelize?
-            foreach (var dataMember in data.Members)
+            // Determine which members already exist and which ones need to be created
+            var existingMembers = await _members.GetBySystem(system);
+            foreach (var d in data.Members)
             {
-                // If member's given an ID, we try to look up the member with the given ID
-                PKMember member = null;
-                if (dataMember.Id != null)
+                // Try to look up the member with the given ID
+                var match = existingMembers.FirstOrDefault(m => m.Hid.Equals(d.Id));
+                if (match == null)
+                    match = existingMembers.FirstOrDefault(m => m.Name.Equals(d.Name)); // Try with the name instead
+                if (match != null)
                 {
-                    member = await _members.GetByHid(dataMember.Id);
-
-                    // ...but if it's a different system's member, we just make a new one anyway
-                    if (member != null && member.System != system.Id) member = null;
-                }
-
-                // Try to look up by name, too
-                if (member == null) member = await _members.GetByName(system, dataMember.Name);
-
-                // And if all else fails (eg. fresh import from Tupperbox, etc) we just make a member lol
-                if (member == null)
-                {
-                    member = await _members.Create(system, dataMember.Name);
-                    result.AddedNames.Add(dataMember.Name);
+                    dataFileToMemberMapping.Add(d.Id, match); // Relate the data file ID to the PKMember for importing switches
+                    result.ModifiedNames.Add(d.Name);
                 }
                 else
                 {
-                    result.ModifiedNames.Add(dataMember.Name);
+                    unmappedMembers.Add(d); // Track members that weren't found so we can create them all
+                    result.AddedNames.Add(d.Name);
                 }
+            }
 
-                // Keep track of what the data file's member ID maps to for switch import
-                if (!hidMapping.ContainsKey(dataMember.Id))
-                    hidMapping.Add(dataMember.Id, member);
+            // If creating the unmatched members would put us over the member limit, abort before creating any members
+            // new total: # in the system + (# in the file - # in the file that already exist)
+            if (data.Members.Count - dataFileToMemberMapping.Count + existingMembers.Count() >= Limits.MaxMemberCount)
+            {
+                result.Success = false;
+                result.Message = $"Import would exceed the maximum number of members ({Limits.MaxMemberCount}).";
+                result.AddedNames.Clear();
+                result.ModifiedNames.Clear();
+                return result;
+            }
+
+            // Create all unmapped members in one transaction
+            // These consist of members from another PluralKit system or another framework (e.g. Tupperbox)
+            var membersToCreate = new Dictionary<string, string>();
+            unmappedMembers.ForEach(x => membersToCreate.Add(x.Id, x.Name));
+            var newMembers = await _members.CreateMultiple(system, membersToCreate);
+            foreach (var member in newMembers)
+                dataFileToMemberMapping.Add(member.Key, member.Value);
+
+            // Update members with data file properties
+            // TODO: parallelize?
+            foreach (var dataMember in data.Members)
+            {
+                dataFileToMemberMapping.TryGetValue(dataMember.Id, out PKMember member);
+                if (member == null)
+                    continue;
 
                 // Apply member info
                 member.Name = dataMember.Name;
@@ -161,7 +161,7 @@ namespace PluralKit.Bot
                 if (dataMember.Birthday != null)
                 {
                     var birthdayParse = Formats.DateExportFormat.Parse(dataMember.Birthday);
-                    member.Birthday = birthdayParse.Success ? (LocalDate?) birthdayParse.Value : null;
+                    member.Birthday = birthdayParse.Success ? (LocalDate?)birthdayParse.Value : null;
                 }
 
                 await _members.Save(member);
@@ -174,7 +174,7 @@ namespace PluralKit.Bot
                 var timestamp = InstantPattern.ExtendedIso.Parse(sw.Timestamp).Value;
                 var swMembers = new List<PKMember>();
                 swMembers.AddRange(sw.Members.Select(x =>
-                    hidMapping.FirstOrDefault(y => y.Key.Equals(x)).Value));
+                    dataFileToMemberMapping.FirstOrDefault(y => y.Key.Equals(x)).Value));
                 var mapped = new Tuple<Instant, ICollection<PKMember>>(timestamp, swMembers);
                 mappedSwitches.Add(mapped);
             }
@@ -182,8 +182,6 @@ namespace PluralKit.Bot
             await _switches.RegisterSwitches(system, mappedSwitches);
 
             _logger.Information("Imported system {System}", system.Id);
-
-            result.System = system;
             return result;
         }
     }
@@ -193,6 +191,8 @@ namespace PluralKit.Bot
         public ICollection<string> AddedNames;
         public ICollection<string> ModifiedNames;
         public PKSystem System;
+        public bool Success;
+        public string Message;
     }
 
     public struct DataFileSystem

--- a/PluralKit.Core/Limits.cs
+++ b/PluralKit.Core/Limits.cs
@@ -5,6 +5,8 @@ namespace PluralKit.Core {
 
         public static readonly int MaxSystemNameLength = 100;
         public static readonly int MaxSystemTagLength = MaxProxyNameLength - 1;
+        public static readonly int MaxMemberCount = 1000;
+        public static readonly int MaxMembersWarnThreshold = MaxMemberCount - 50;
         public static readonly int MaxDescriptionLength = 1000;
         public static readonly int MaxMemberNameLength = 100; // Fair bit larger than MaxProxyNameLength for bookkeeping
         public static readonly int MaxPronounsLength = 100;

--- a/PluralKit.Core/Stores.cs
+++ b/PluralKit.Core/Stores.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using App.Metrics.Logging;
 using Dapper;
 using NodaTime;
-
+using Npgsql;
 using PluralKit.Core;
 
 using Serilog;
@@ -345,6 +345,77 @@ namespace PluralKit {
             }
         }
 
+        public async Task BulkImportSwitches(PKSystem system, ICollection<Tuple<Instant, ICollection<PKMember>>> switches)
+        {
+            // Read existing switches to enforce unique timestamps
+            var priorSwitches = await GetSwitches(system);
+            var lastSwitchId = priorSwitches.Any()
+                ? priorSwitches.Max(x => x.Id)
+                : 0;
+            
+            using (var conn = (PerformanceTrackingConnection) await _conn.Obtain())
+            {
+                using (var tx = conn.BeginTransaction())
+                {
+                    // Import switches in bulk
+                    using (var importer = conn.BeginBinaryImport("COPY switches (system, timestamp) FROM STDIN (FORMAT BINARY)"))
+                    {
+                        foreach (var sw in switches)
+                        {
+                            // If there's already a switch at this time, move on
+                            if (priorSwitches.Any(x => x.Timestamp.Equals(sw.Item1)))
+                                continue;
+
+                            // Otherwise, add it to the importer
+                            importer.StartRow();
+                            importer.Write(system.Id, NpgsqlTypes.NpgsqlDbType.Integer);
+                            importer.Write(sw.Item1, NpgsqlTypes.NpgsqlDbType.Timestamp);
+                        }
+                        importer.Complete(); // Commits the copy operation so dispose won't roll it back
+                    }
+
+                    // Get all switches that were created above and don't have members for ID lookup
+                    var switchesWithoutMembers =
+                        await conn.QueryAsync<PKSwitch>(@"
+                        SELECT switches.*
+                        FROM switches
+                        LEFT JOIN switch_members
+                        ON switch_members.switch = switches.id
+                        WHERE switches.id > @LastSwitchId
+                        AND switches.system = @System
+                        AND switch_members.id IS NULL", new { LastSwitchId = lastSwitchId, System = system.Id });
+
+                    // Import switch_members in bulk
+                    using (var importer = conn.BeginBinaryImport("COPY switch_members (switch, member) FROM STDIN (FORMAT BINARY)"))
+                    {
+                        // Iterate over the switches we created above and set their members
+                        foreach (var pkSwitch in switchesWithoutMembers)
+                        {
+                            // If this isn't in our import set, move on
+                            var sw = switches.FirstOrDefault(x => x.Item1.Equals(pkSwitch.Timestamp));
+                            if (sw == null)
+                                continue;
+
+                            // Loop through associated members to add each to the switch
+                            foreach (var m in sw.Item2)
+                            {
+                                // Skip switch-outs - these don't have switch_members
+                                if (m == null)
+                                    continue;
+                                importer.StartRow();
+                                importer.Write(pkSwitch.Id, NpgsqlTypes.NpgsqlDbType.Integer);
+                                importer.Write(m.Id, NpgsqlTypes.NpgsqlDbType.Integer);
+                            }
+                        }
+                        importer.Complete(); // Commits the copy operation so dispose won't roll it back
+                    }
+                    tx.Commit();
+                }
+            }
+
+            _logger.Information("Completed bulk import of switches for system {0}", system.Hid);
+        }
+        
         public async Task RegisterSwitches(PKSystem system, ICollection<Tuple<Instant, ICollection<PKMember>>> switches)
         {
             // Use a transaction here since we're doing multiple executed commands in one

--- a/PluralKit.Core/Utils.cs
+++ b/PluralKit.Core/Utils.cs
@@ -488,6 +488,11 @@ namespace PluralKit
             _impl.Open();
         }
 
+        public NpgsqlBinaryImporter BeginBinaryImport(string copyFromCommand)
+        {
+            return _impl.BeginBinaryImport(copyFromCommand);
+        }
+
         public string ConnectionString
         {
             get => _impl.ConnectionString;


### PR DESCRIPTION
- Asks for confirmation before clearing a system or member property (i.e. issuing a command without any parameters)
  - This will provide a buffer between issuing the command with the intention to show the property (which is what `pk;member <name>` does) and actually clearing the property