### PR TITLE
Display guild user nickname on message card if set

### DIFF
--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -176,7 +176,7 @@ namespace PluralKit.Bot {
                         .OrderByDescending(role => role.Position)
                         .ToList();
 
-                    userStr = guildUser?.NameAndMention();
+                    userStr = guildUser.Nickname != null ? $"**Username:** {guildUser?.NameAndMention()}\n**Nickname:** {guildUser.Nickname}" : guildUser?.NameAndMention();
                 }
             }
 


### PR DESCRIPTION
- If someone reacts to a proxied message in a server, and the user who sent the message has a server nickname, display the username and mention on one line, and server nickname of that user on another line