### PR TITLE
Move hid generation into database functions

### DIFF
--- a/PluralKit.Core/Utils.cs
+++ b/PluralKit.Core/Utils.cs
@@ -32,18 +32,6 @@ namespace PluralKit
 {
     public static class Utils
     {
-        public static string GenerateHid()
-        {
-            var rnd = new Random();
-            var charset = "abcdefghijklmnopqrstuvwxyz";
-            string hid = "";
-            for (int i = 0; i < 5; i++)
-            {
-                hid += charset[rnd.Next(charset.Length)];
-            }
-            return hid;
-        }
-
         public static string GenerateToken()
         {
             var buf = new byte[48]; // Results in a 64-byte Base64 string (no padding)


### PR DESCRIPTION
The hid columns on systems and members tables are now generated automatically on insert. Much like their primary keys, the application can now trust the database to provide these values.

* Adds three new functions to the database:
   - generate_hid - equivalent of the GenerateHid utility method we had before, makes a new hid
   - new_system_hid - calls generate_hid in a loop until unique across systems
   - new_member_hid - calls generate_hid in a loop until unique across members
* Sets the default for hid columns on members and systems tables to use the functions above
* Removes while loops from create system/member methods in favor of letting the database handle the IDs
* Removes the now unused GenerateHid utility method