### PR TITLE
Add pagination to front history card

### DIFF
--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -32,7 +32,7 @@ namespace PluralKit.Bot {
                 .WithTitle(system.Name ?? null)
                 .WithThumbnailUrl(system.AvatarUrl ?? null)
                 .WithFooter($"System ID: {system.Hid} | Created on {Formats.ZonedDateTimeFormat.Format(system.Created.InZone(system.Zone))}");
- 
+
             var latestSwitch = await _data.GetLatestSwitch(system);
             if (latestSwitch != null)
             {
@@ -109,40 +109,6 @@ namespace PluralKit.Bot {
                 .WithColor(members.FirstOrDefault()?.Color?.ToDiscordColor() ?? Color.Blue)
                 .AddField($"Current {"fronter".ToQuantity(members.Count, ShowQuantityAs.None)}", members.Count > 0 ? string.Join(", ", members.Select(m => m.Name)) : "*(no fronter)*")
                 .AddField("Since", $"{Formats.ZonedDateTimeFormat.Format(sw.Timestamp.InZone(zone))} ({Formats.DurationFormat.Format(timeSinceSwitch)} ago)")
-                .Build();
-        }
-
-        public async Task<Embed> CreateFrontHistoryEmbed(IEnumerable<PKSwitch> sws, DateTimeZone zone)
-        {
-            var outputStr = "";
-
-            PKSwitch lastSw = null;
-            foreach (var sw in sws)
-            {
-                // Fetch member list and format
-                var members = (await _data.GetSwitchMembers(sw)).ToList();
-                var membersStr = members.Any() ? string.Join(", ", members.Select(m => m.Name)) : "no fronter";
-
-                var switchSince = SystemClock.Instance.GetCurrentInstant() - sw.Timestamp;
-
-                // If this isn't the latest switch, we also show duration
-                if (lastSw != null)
-                {
-                    // Calculate the time between the last switch (that we iterated - ie. the next one on the timeline) and the current one
-                    var switchDuration = lastSw.Timestamp - sw.Timestamp;
-                    outputStr += $"**{membersStr}** ({Formats.ZonedDateTimeFormat.Format(sw.Timestamp.InZone(zone))}, {Formats.DurationFormat.Format(switchSince)} ago, for {Formats.DurationFormat.Format(switchDuration)})\n";
-                }
-                else
-                {
-                    outputStr += $"**{membersStr}** ({Formats.ZonedDateTimeFormat.Format(sw.Timestamp.InZone(zone))}, {Formats.DurationFormat.Format(switchSince)} ago)\n";
-                }
-
-                lastSw = sw;
-            }
-
-            return new EmbedBuilder()
-                .WithTitle("Past switches")
-                .WithDescription(outputStr)
                 .Build();
         }
 

--- a/docs/2-command-list.md
+++ b/docs/2-command-list.md
@@ -19,7 +19,7 @@ Words in \<angle brackets> are *required parameters*. Words in [square brackets]
 - `pk;system timezone [location]` - Changes the time zone of your system.
 - `pk;system delete` - Deletes your system.
 - `pk;system [id] fronter` - Shows the current fronter of a system.
-- `pk;system [id] fronthistory` - Shows a paginated list of the most recent fronters of a system.
+- `pk;system [id] fronthistory [items per page]` - Shows a paginated list of the most recent fronters of a system.
 - `pk;system [id] frontpercent [timeframe]` - Shows the aggregated front history of a system within a given time frame.
 - `pk;system [id] list` - Shows a paginated list of a system's members.
 - `pk;system [id] list full` - Shows a paginated list of a system's members, with increased detail.

--- a/docs/2-command-list.md
+++ b/docs/2-command-list.md
@@ -19,7 +19,7 @@ Words in \<angle brackets> are *required parameters*. Words in [square brackets]
 - `pk;system timezone [location]` - Changes the time zone of your system.
 - `pk;system delete` - Deletes your system.
 - `pk;system [id] fronter` - Shows the current fronter of a system.
-- `pk;system [id] fronthistory` - Shows the last 10 fronters of a system.
+- `pk;system [id] fronthistory` - Shows a paginated list of the most recent fronters of a system.
 - `pk;system [id] frontpercent [timeframe]` - Shows the aggregated front history of a system within a given time frame.
 - `pk;system [id] list` - Shows a paginated list of a system's members.
 - `pk;system [id] list full` - Shows a paginated list of a system's members, with increased detail.


### PR DESCRIPTION
When viewing front history for a system, results are now displayed in pages of 10 instead of displaying only the most recent 10. This addresses #111.

The implementation now uses the same logic as the frontpercent command for determining switch end times to reduce duplicated code and the number of database round trips.