### PR TITLE
Send error if both prefix and suffix are empty when changing proxy tags

### DIFF
--- a/PluralKit.Bot/Commands/MemberCommands.cs
+++ b/PluralKit.Bot/Commands/MemberCommands.cs
@@ -173,6 +173,9 @@ namespace PluralKit.Bot.Commands
             if (prefixAndSuffix.Length < 2) throw Errors.ProxyMustHaveText;
             if (prefixAndSuffix.Length > 2) throw Errors.ProxyMultipleText;
 
+            // If the prefix and suffix are *both* empty, send an error.
+            if (prefixAndSuffix[0].Length == 0 && prefixAndSuffix[1].Length == 0) throw Errors.NoProxyTags; 
+
             // If the prefix/suffix is empty, use "null" instead (for DB)
             target.Prefix = prefixAndSuffix[0].Length > 0 ? prefixAndSuffix[0] : null;
             target.Suffix = prefixAndSuffix[1].Length > 0 ? prefixAndSuffix[1] : null;

--- a/PluralKit.Bot/Errors.cs
+++ b/PluralKit.Bot/Errors.cs
@@ -28,7 +28,7 @@ namespace PluralKit.Bot {
         public static PKError BirthdayParseError(string birthday) => new PKError($"\"{birthday.SanitizeMentions()}\" could not be parsed as a valid date. Try a format like \"2016-12-24\" or \"May 3 1996\".");
         public static PKError ProxyMustHaveText => new PKSyntaxError("Example proxy message must contain the string 'text'.");
         public static PKError ProxyMultipleText => new PKSyntaxError("Example proxy message must contain the string 'text' exactly once.");
-        
+        public static PKError NoProxyTags => new PKError("Example proxy message must include the proxy tags! See the guide linked below.\n<https://pluralkit.me/guide#setting-up-proxy-tags>\nPerhaps you were trying to clear the proxy tags? The syntax for that is:\n-`pk;member <member> proxy`");
         public static PKError MemberDeleteCancelled => new PKError($"Member deletion cancelled. Stay safe! {Emojis.ThumbsUp}");
         public static PKError AvatarServerError(HttpStatusCode statusCode) => new PKError($"Server responded with status code {(int) statusCode}, are you sure your link is working?");
         public static PKError AvatarFileSizeLimit(long size) => new PKError($"File size too large ({size.Bytes().ToString("#.#")} > {Limits.AvatarFileSizeLimit.Bytes().ToString("#.#")}), try shrinking or compressing the image.");


### PR DESCRIPTION
If someone tries to change their proxy tags to `text`, it will clear them (but send a message saying it "changed them to `text`". This can be confusing for users who may not understand how to set proxy tags.
Instead, send an error with a link to the proxying guide, with a sidenote on how to clear the proxy tags if that is the requested action.