### PR TITLE
Moved the generation of hids to the database layer

### DIFF
--- a/PluralKit.Core/Migrations/6.sql
+++ b/PluralKit.Core/Migrations/6.sql
@@ -1,0 +1,38 @@
+-- SCHEMA VERSION 5: 2020-02-25
+-- Creating functions to generate hids for when creating systems or members
+
+CREATE OR REPLACE FUNCTION generatesystemhid()
+RETURNS CHAR(5) as $$
+DECLARE
+    newHid CHAR(5);
+BEGIN
+    LOOP
+        SELECT array_to_string(ARRAY(
+            SELECT chr((ascii('b') + round(random() * 25)) :: integer) 
+            FROM generate_series(1,5)), 
+             '') INTO newHid;
+        EXIT WHEN (SELECT COUNT(*) FROM systems WHERE hid = newHid) = 0;
+    END LOOP;
+    return newHid;
+END;
+
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION generatememberhid()
+RETURNS CHAR(5) as $$
+DECLARE
+    newHid CHAR(5);
+BEGIN
+    LOOP
+        SELECT array_to_string(ARRAY(
+            SELECT chr((ascii('b') + round(random() * 25)) :: integer) 
+            FROM generate_series(1,5)), 
+             '') INTO newHid;
+        EXIT WHEN (SELECT COUNT(*) FROM members WHERE hid = newHid) = 0;
+    END LOOP;
+    return newHid;
+END;
+$$ LANGUAGE plpgsql;
+
+update info set schema_version = 6;

--- a/PluralKit.Core/Services/PostgresDataStore.cs
+++ b/PluralKit.Core/Services/PostgresDataStore.cs
@@ -61,15 +61,10 @@ namespace PluralKit.Core {
         }
 
         public async Task<PKSystem> CreateSystem(string systemName = null) {
-            string hid;
-            do
-            {
-                hid = StringUtils.GenerateHid();
-            } while (await GetSystemByHid(hid) != null);
 
             PKSystem system;
             using (var conn = await _conn.Obtain())
-                system = await conn.QuerySingleAsync<PKSystem>("insert into systems (hid, name) values (@Hid, @Name) returning *", new { Hid = hid, Name = systemName });
+                system = await conn.QuerySingleAsync<PKSystem>("insert into systems (hid, name) values (generatesystemhid(), @Name) returning *", new {Name = systemName });
 
             _logger.Information("Created system {System}", system.Id);
             // New system has no accounts, therefore nothing gets cached, therefore no need to invalidate caches right here
@@ -155,16 +150,9 @@ namespace PluralKit.Core {
         }
 
         public async Task<PKMember> CreateMember(PKSystem system, string name) {
-            string hid;
-            do
-            {
-                hid = StringUtils.GenerateHid();
-            } while (await GetMemberByHid(hid) != null);
-
             PKMember member;
             using (var conn = await _conn.Obtain())
-                member = await conn.QuerySingleAsync<PKMember>("insert into members (hid, system, name) values (@Hid, @SystemId, @Name) returning *", new {
-                    Hid = hid,
+                member = await conn.QuerySingleAsync<PKMember>("insert into members (hid, system, name) values (generatememberhid(), @SystemId, @Name) returning *", new {
                     SystemID = system.Id,
                     Name = name
                 });
@@ -182,17 +170,8 @@ namespace PluralKit.Core {
                 var results = new Dictionary<string, PKMember>();
                 foreach (var name in names)
                 {
-                    string hid;
-                    do
+                    var member = await conn.QuerySingleAsync<PKMember>("INSERT INTO members (generatememberhid(), system, name) VALUES (@Hid, @SystemId, @Name) RETURNING *", new
                     {
-                        hid = await conn.QuerySingleOrDefaultAsync<string>("SELECT @Hid WHERE NOT EXISTS (SELECT id FROM members WHERE hid = @Hid LIMIT 1)", new
-                        {
-                            Hid = StringUtils.GenerateHid()
-                        });
-                    } while (hid == null);
-                    var member = await conn.QuerySingleAsync<PKMember>("INSERT INTO members (hid, system, name) VALUES (@Hid, @SystemId, @Name) RETURNING *", new
-                    {
-                        Hid = hid,
                         SystemID = system.Id,
                         Name = name.Value
                     });

--- a/PluralKit.Core/Services/PostgresDataStore.cs
+++ b/PluralKit.Core/Services/PostgresDataStore.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -170,7 +170,8 @@ namespace PluralKit.Core {
                 var results = new Dictionary<string, PKMember>();
                 foreach (var name in names)
                 {
-                    var member = await conn.QuerySingleAsync<PKMember>("INSERT INTO members (generatememberhid(), system, name) VALUES (@Hid, @SystemId, @Name) RETURNING *", new
+                    
+                    var member = await conn.QuerySingleAsync<PKMember>("INSERT INTO members (hid, system, name) VALUES (generatememberhid(), @SystemId, @Name) RETURNING *", new
                     {
                         SystemID = system.Id,
                         Name = name.Value

--- a/PluralKit.Core/Services/SchemaService.cs
+++ b/PluralKit.Core/Services/SchemaService.cs
@@ -11,7 +11,7 @@ using Serilog;
 namespace PluralKit.Core {
     public class SchemaService
     {
-        private const int TargetSchemaVersion = 5;
+        private const int TargetSchemaVersion = 6;
 
         private DbConnectionFactory _conn;
         private ILogger _logger;


### PR DESCRIPTION
generating hids on the application layer and pinging the database to check if its valid in a loop is inefficient and is only going to get worse as more and more system entries or member entries are created