### PR TITLE
Add disabling reaction pings

### DIFF
--- a/PluralKit.Bot/Commands/CommandTree.cs
+++ b/PluralKit.Bot/Commands/CommandTree.cs
@@ -24,6 +24,7 @@ namespace PluralKit.Bot
         public static Command SystemFrontHistory = new Command("system fronthistory", "system [system] fronthistory", "Shows a system's front history");
         public static Command SystemFrontPercent = new Command("system frontpercent", "system [system] frontpercent [timespan]", "Shows a system's front breakdown");
         public static Command SystemPrivacy = new Command("system privacy", "system privacy <description|members|fronter|fronthistory> <public|private>", "Changes your system's privacy settings");
+        public static Command SystemPing = new Command("system ping", "system ping <enable|disable>", "Changes your system's ping preferences");
         public static Command Autoproxy = new Command("autoproxy", "autoproxy [off|front|latch|member]", "Sets your system's autoproxy mode for this server");
         public static Command MemberInfo = new Command("member", "member <member>", "Looks up information about a member");
         public static Command MemberNew = new Command("member new", "member new <name>", "Creates a new member");
@@ -199,6 +200,8 @@ namespace PluralKit.Bot
                 await ctx.Execute<SystemFront>(SystemFrontPercent, m => m.SystemFrontPercent(ctx, ctx.System));
             else if (ctx.Match("privacy"))
                 await ctx.Execute<SystemEdit>(SystemPrivacy, m => m.SystemPrivacy(ctx));
+            else if (ctx.Match("ping"))
+                await ctx.Execute<SystemEdit>(SystemPing, m => m.SystemPing(ctx));
             else if (ctx.Match("commands", "help"))
                 await PrintCommandList(ctx, "systems", SystemCommands);
             else if (!ctx.HasNext()) // Bare command

--- a/PluralKit.Bot/Commands/SystemEdit.cs
+++ b/PluralKit.Bot/Commands/SystemEdit.cs
@@ -310,6 +310,29 @@ namespace PluralKit.Bot
             await ctx.Reply($"System {subjectStr} privacy has been set to **{levelStr}**. Other accounts will now {levelExplanation} your system {subjectStr}.");
         }
 
+        public async Task SystemPing(Context ctx) 
+	{
+	    ctx.CheckSystem();
+
+	    if (!ctx.HasNext()) 
+	    {
+		    if (ctx.System.Pings) {await ctx.Reply("Reaction pings are currently **enabled** for your system. To disable reaction pings, type `pk;s ping disable`.");}
+		    else {await ctx.Reply("Reaction pings are currently **disabled** for your system. To enable reaction pings, type `pk;s ping enable`.");}
+	    }
+        else {
+            if (ctx.Match("on", "enable")) {
+                ctx.System.Pings = true;
+                await _data.SaveSystem(ctx.System);
+                await ctx.Reply("Reaction pings have now been enabled.");
+            }
+            if (ctx.Match("off", "disable")) {
+                ctx.System.Pings = false;
+                await _data.SaveSystem(ctx.System);
+                await ctx.Reply("Reaction pings have now been disabled.");
+            }
+        }
+	}
+
         public async Task<DateTimeZone> FindTimeZone(Context ctx, string zoneStr) {
             // First, if we're given a flag emoji, we extract the flag emoji code from it.
             zoneStr = Core.StringUtils.ExtractCountryFlag(zoneStr) ?? zoneStr;

--- a/PluralKit.Bot/Services/ProxyService.cs
+++ b/PluralKit.Bot/Services/ProxyService.cs
@@ -289,6 +289,12 @@ namespace PluralKit.Bot
             // If they don't have Send Messages permission, bail (since PK shouldn't send anything on their behalf)
             if (!permissions.SendMessages || !permissions.ViewChannel) return;
 
+	    if (!msg.System.Pings) {
+		    await channel.SendMessageAsync($"Hey <@{userWhoReacted}>, {msg.Member.DisplayName ?? msg.Member.Name}'s system has disabled reaction pings. You can mention them by copy pasting the following message:");
+		    await channel.SendMessageAsync($"`<@{msg.Message.Sender}>`");
+		    return;
+	    }
+
             var embed = new EmbedBuilder().WithDescription($"[Jump to pinged message]({realMessage.GetJumpUrl()})");
             await channel.SendMessageAsync($"Psst, **{msg.Member.DisplayName ?? msg.Member.Name}** (<@{msg.Message.Sender}>), you have been pinged by <@{userWhoReacted}>.", embed: embed.Build());
             

--- a/PluralKit.Core/Migrations/5.sql
+++ b/PluralKit.Core/Migrations/5.sql
@@ -1,3 +1,3 @@
-﻿-- SCHEMA VERSION 4: 2020-02-14
+﻿-- SCHEMA VERSION 5: 2020-02-14
 alter table servers add column log_cleanup_enabled bool not null default false;
 update info set schema_version = 5;

--- a/PluralKit.Core/Migrations/6.sql
+++ b/PluralKit.Core/Migrations/6.sql
@@ -1,0 +1,3 @@
+-- SCHEMA VERSION 6: 2020-03-21
+alter table systems add column pings bool not null default true;
+update info set schema_version = 6;

--- a/PluralKit.Core/Models/PKSystem.cs
+++ b/PluralKit.Core/Models/PKSystem.cs
@@ -18,7 +18,7 @@ namespace PluralKit.Core {
         [JsonProperty("created")] public Instant Created { get; set; }
         [JsonProperty("tz")] public string UiTz { get; set; }
         [JsonProperty("ping")] public bool Pings { get; set; }
-	public PrivacyLevel DescriptionPrivacy { get; set; }
+	    public PrivacyLevel DescriptionPrivacy { get; set; }
         public PrivacyLevel MemberListPrivacy { get; set; }
         public PrivacyLevel FrontPrivacy { get; set; }
         public PrivacyLevel FrontHistoryPrivacy { get; set; }

--- a/PluralKit.Core/Models/PKSystem.cs
+++ b/PluralKit.Core/Models/PKSystem.cs
@@ -17,7 +17,8 @@ namespace PluralKit.Core {
         [JsonIgnore] public string Token { get; set; }
         [JsonProperty("created")] public Instant Created { get; set; }
         [JsonProperty("tz")] public string UiTz { get; set; }
-        public PrivacyLevel DescriptionPrivacy { get; set; }
+        [JsonProperty("ping")] public bool Pings { get; set; }
+	public PrivacyLevel DescriptionPrivacy { get; set; }
         public PrivacyLevel MemberListPrivacy { get; set; }
         public PrivacyLevel FrontPrivacy { get; set; }
         public PrivacyLevel FrontHistoryPrivacy { get; set; }

--- a/PluralKit.Core/Services/PostgresDataStore.cs
+++ b/PluralKit.Core/Services/PostgresDataStore.cs
@@ -118,7 +118,7 @@ namespace PluralKit.Core {
 
         public async Task SaveSystem(PKSystem system) {
             using (var conn = await _conn.Obtain())
-                await conn.ExecuteAsync("update systems set name = @Name, description = @Description, tag = @Tag, avatar_url = @AvatarUrl, token = @Token, ui_tz = @UiTz, description_privacy = @DescriptionPrivacy, member_list_privacy = @MemberListPrivacy, front_privacy = @FrontPrivacy, front_history_privacy = @FrontHistoryPrivacy where id = @Id", system);
+                await conn.ExecuteAsync("update systems set name = @Name, description = @Description, tag = @Tag, avatar_url = @AvatarUrl, token = @Token, ui_tz = @UiTz, description_privacy = @DescriptionPrivacy, member_list_privacy = @MemberListPrivacy, front_privacy = @FrontPrivacy, front_history_privacy = @FrontHistoryPrivacy, pings = @Pings where id = @Id", system);
 
             _logger.Information("Updated system {@System}", system);
             await _cache.InvalidateSystem(system);

--- a/PluralKit.Core/Services/SchemaService.cs
+++ b/PluralKit.Core/Services/SchemaService.cs
@@ -11,7 +11,7 @@ using Serilog;
 namespace PluralKit.Core {
     public class SchemaService
     {
-        private const int TargetSchemaVersion = 5;
+        private const int TargetSchemaVersion = 6;
 
         private DbConnectionFactory _conn;
         private ILogger _logger;


### PR DESCRIPTION
Some users may not like being pinged by bot accounts. Users trying to ping a system who disabled pings will get a message informing them of that, and a subsequent message from which they can copy paste the account's mention.