### PR TITLE
qol/private display name

### DIFF
--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -77,7 +77,7 @@ namespace PluralKit.Bot {
 
         public async Task<DiscordEmbed> CreateMemberEmbed(PKSystem system, PKMember member, DiscordGuild guild, LookupContext ctx)
         {
-            var name = member.Name;
+            var name = member.MemberPrivacy.CanAccess(ctx) && member.DisplayName != null ? member.Name : member.DisplayName ?? member.Name;
             if (system.Name != null) name = $"{member.Name} ({system.Name})";
 
             DiscordColor color;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     restart: always
   api:
     image: pluralkit
+    build: .
     command: ["PluralKit.API.dll"]
     environment:
       - "PluralKit:Database=Host=db;Username=postgres;Password=postgres;Database=postgres;Maximum Pool Size=1000"


### PR DESCRIPTION
A small pr that shows the display name of a member in place of their name, where the member is private and the user looking up the member does not have permission to view the full profile