### PR TITLE
Properly show tags containing markdown in system embed

### DIFF
--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -46,7 +46,7 @@ namespace PluralKit.Bot {
                         string.Join(", ", switchMembers.Select(m => m.Name)));
             }
 
-            if (system.Tag != null) eb.AddField("Tag", system.Tag);
+            if (system.Tag != null) eb.AddField("Tag", system.Tag.EscapeMarkdown());
             eb.AddField("Linked accounts", string.Join(", ", users).Truncate(1000), true);
 
             if (system.MemberListPrivacy.CanAccess(ctx))


### PR DESCRIPTION
Small bugfix to escape markdown for system tags.