### PR TITLE
Fix emoji variation selector issue

### DIFF
--- a/PluralKit.Bot/Services/ProxyService.cs
+++ b/PluralKit.Bot/Services/ProxyService.cs
@@ -76,6 +76,7 @@ namespace PluralKit.Bot
                 if (isMatch) {
                     var inner = message.Substring(prefix.Length, message.Length - prefix.Length - suffix.Length);
                     if (leadingMention != null) inner = $"{leadingMention} {inner}";
+                    if (inner == "\U0000fe0f") return null;
                     return new ProxyMatch { Member = match, System = system, InnerText = inner, ProxyTags = tag};
                 }
             }


### PR DESCRIPTION
This fixes an issue where a message that contains an emoji sent by Discord with a "variation selector" (unicode `\U0000fe0f`) might be proxied as a member whose proxy prefix is the unicode emoji without that variation selector.