### PR TITLE
Feature/prefix tags

### DIFF
--- a/PluralKit.API/Controllers/v1/JsonModelExt.cs
+++ b/PluralKit.API/Controllers/v1/JsonModelExt.cs
@@ -15,7 +15,7 @@ namespace PluralKit.API
             o.Add("id", system.Hid);
             o.Add("name", system.Name);
             o.Add("description", system.DescriptionFor(ctx));
-            o.Add("tag", system.Tag);
+            o.Add("tag", system.TagSuffix);
             o.Add("avatar_url", system.AvatarUrl);
             o.Add("created", system.Created.FormatExport());
             o.Add("tz", system.UiTz);
@@ -30,7 +30,7 @@ namespace PluralKit.API
         {
             if (o.ContainsKey("name")) system.Name = o.Value<string>("name").NullIfEmpty().BoundsCheckField(Limits.MaxSystemNameLength, "System name");
             if (o.ContainsKey("description")) system.Description = o.Value<string>("description").NullIfEmpty().BoundsCheckField(Limits.MaxDescriptionLength, "System description");
-            if (o.ContainsKey("tag")) system.Tag = o.Value<string>("tag").NullIfEmpty().BoundsCheckField(Limits.MaxSystemTagLength, "System tag");
+            if (o.ContainsKey("tag")) system.TagSuffix = o.Value<string>("tag").NullIfEmpty().BoundsCheckField(Limits.MaxSystemTagLength, "System tag");
             if (o.ContainsKey("avatar_url")) system.AvatarUrl = o.Value<string>("avatar_url").NullIfEmpty().BoundsCheckField(Limits.MaxUriLength, "System avatar URL");
             if (o.ContainsKey("tz")) system.UiTz = o.Value<string>("tz") ?? "UTC";
             

--- a/PluralKit.Bot/Commands/SystemEdit.cs
+++ b/PluralKit.Bot/Commands/SystemEdit.cs
@@ -96,15 +96,15 @@ namespace PluralKit.Bot
 
             if (ctx.MatchFlag("c", "clear") || ctx.Match("clear"))
             {
-                ctx.System.Tag = null;
+                ctx.System.TagSuffix = null;
                 await _data.SaveSystem(ctx.System);
                 await ctx.Reply($"{Emojis.Success} System tag cleared.");
             } else if (!ctx.HasNext(skipFlags: false))
             {
-                if (ctx.System.Tag == null)
+                if (ctx.System.TagSuffix == null)
                     await ctx.Reply($"You currently have no system tag. To set one, type `pk;s tag <tag>`.");
                 else
-                    await ctx.Reply($"Your current system tag is `{ctx.System.Tag}`. To change it, type `pk;s tag <tag>`. To clear it, type `pk;s tag -clear`.");
+                    await ctx.Reply($"Your current system tag is `{ctx.System.TagSuffix}`. To change it, type `pk;s tag <tag>`. To clear it, type `pk;s tag -clear`.");
             }
             else
             {
@@ -112,7 +112,7 @@ namespace PluralKit.Bot
                 if (newTag != null)
                     if (newTag.Length > Limits.MaxSystemTagLength)
                         throw Errors.SystemNameTooLongError(newTag.Length);
-                ctx.System.Tag = newTag;
+                ctx.System.TagSuffix = newTag;
                 await _data.SaveSystem(ctx.System);
                 await ctx.Reply($"{Emojis.Success} System tag changed. Member names will now end with `{newTag}` when proxied.");
             }

--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -50,7 +50,7 @@ namespace PluralKit.Bot {
                         string.Join(", ", switchMembers.Select(m => m.NameFor(ctx))));
             }
 
-            if (system.Tag != null) eb.AddField("Tag", system.Tag.EscapeMarkdown());
+            if (system.TagSuffix != null) eb.AddField("Tag", system.TagSuffix.EscapeMarkdown());
             eb.AddField("Linked accounts", string.Join(", ", users).Truncate(1000), true);
 
             if (system.MemberListPrivacy.CanAccess(ctx))

--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -50,7 +50,9 @@ namespace PluralKit.Bot {
                         string.Join(", ", switchMembers.Select(m => m.NameFor(ctx))));
             }
 
-            if (system.TagSuffix != null) eb.AddField("Tag", system.TagSuffix.EscapeMarkdown());
+            if (system.TagPrefix != null) eb.AddField("Tag Prefix", system.TagPrefix.EscapeMarkdown(), true);
+            if (system.TagSuffix != null) eb.AddField("Tag Suffix", system.TagSuffix.EscapeMarkdown(), true);
+
             eb.AddField("Linked accounts", string.Join(", ", users).Truncate(1000), true);
 
             if (system.MemberListPrivacy.CanAccess(ctx))

--- a/PluralKit.Core/Database/Database.cs
+++ b/PluralKit.Core/Database/Database.cs
@@ -20,7 +20,7 @@ namespace PluralKit.Core
     internal class Database: IDatabase
     {
         private const string RootPath = "PluralKit.Core.Database"; // "resource path" root for SQL files
-        private const int TargetSchemaVersion = 8;
+        private const int TargetSchemaVersion = 9;
         
         private readonly CoreConfig _config;
         private readonly ILogger _logger;

--- a/PluralKit.Core/Database/Functions/MessageContext.cs
+++ b/PluralKit.Core/Database/Functions/MessageContext.cs
@@ -22,7 +22,9 @@ namespace PluralKit.Core
         public SwitchId? LastSwitch { get; }
         public MemberId[] LastSwitchMembers { get; } = new MemberId[0];
         public Instant? LastSwitchTimestamp { get; }
-        public string? SystemTag { get; }
+        public string? SystemTagSuffix { get; }
+        public string? SystemTagPrefix { get; }
+
         public string? SystemAvatar { get; }
     }
 }

--- a/PluralKit.Core/Database/Functions/ProxyMember.cs
+++ b/PluralKit.Core/Database/Functions/ProxyMember.cs
@@ -19,9 +19,7 @@ namespace PluralKit.Core
         public string? ServerAvatar { get; }
         public string? Avatar { get; }
 
-        public string ProxyName(MessageContext ctx) => ctx.SystemTag != null
-            ? $"{ServerName ?? DisplayName ?? Name} {ctx.SystemTag}"
-            : ServerName ?? DisplayName ?? Name;
+        public string ProxyName(MessageContext ctx) => $"{ctx.SystemTagPrefix ?? ""}{ServerName ?? DisplayName ?? Name}{ctx.SystemTagSuffix ?? ""}";
 
         public string? ProxyAvatar(MessageContext ctx) => ServerAvatar ?? Avatar ?? ctx.SystemAvatar;
 

--- a/PluralKit.Core/Database/Functions/functions.sql
+++ b/PluralKit.Core/Database/Functions/functions.sql
@@ -13,7 +13,8 @@
         last_switch int,
         last_switch_members int[],
         last_switch_timestamp timestamp,
-        system_tag text,
+        system_tag_prefix text,
+        system_tag_suffix text,
         system_avatar text
     )
 as $$
@@ -36,7 +37,8 @@ as $$
         system_last_switch.switch as last_switch,
         system_last_switch.members as last_switch_members,
         system_last_switch.timestamp as last_switch_timestamp,
-        system.tag as system_tag,
+        system.tag_prefix as system_tag_prefix,
+        system.tag_suffix as system_tag_suffix,
         system.avatar_url as system_avatar
     -- We need a "from" clause, so we just use some bogus data that's always present
     -- This ensure we always have exactly one row going forward, so we can left join afterwards and still get data

--- a/PluralKit.Core/Database/Migrations/9.sql
+++ b/PluralKit.Core/Database/Migrations/9.sql
@@ -1,0 +1,8 @@
+﻿-- SCHEMA VERSION 9
+-- Set up new tables
+alter table systems add column tag_prefix text
+alter table systems rename column tag tag_suffix
+-- Prepare suffixi for new format
+update systems set tag_suffix = concat(" ",tag_suffix)
+-- Update schema
+update info set schema_version = 9;

--- a/PluralKit.Core/Database/Migrations/9.sql
+++ b/PluralKit.Core/Database/Migrations/9.sql
@@ -1,8 +1,8 @@
 ﻿-- SCHEMA VERSION 9
 -- Set up new tables
-alter table systems add column tag_prefix text
-alter table systems rename column tag tag_suffix
--- Prepare suffixi for new format
-update systems set tag_suffix = concat(" ",tag_suffix)
+alter table systems add column tag_prefix text;
+alter table systems rename column tag to tag_suffix;
+-- Prepare suffix for new format
+update systems set tag_suffix = concat(' ',tag_suffix);
 -- Update schema
 update info set schema_version = 9;

--- a/PluralKit.Core/Models/PKSystem.cs
+++ b/PluralKit.Core/Models/PKSystem.cs
@@ -12,7 +12,8 @@ namespace PluralKit.Core {
         public string Hid { get; }
         public string Name { get; set; }
         public string Description { get; set; }
-        public string Tag { get; set; }
+        public string TagSuffix { get; set; }
+        public string TagPrefix { get; set; }
         public string AvatarUrl { get; set; }
         public string Token { get; set; }
         public Instant Created { get; }

--- a/PluralKit.Core/Services/DataFileService.cs
+++ b/PluralKit.Core/Services/DataFileService.cs
@@ -62,7 +62,7 @@ namespace PluralKit.Core
                 Id = system.Hid,
                 Name = system.Name,
                 Description = system.Description,
-                Tag = system.Tag,
+                Tag = system.TagSuffix,
                 AvatarUrl = system.AvatarUrl,
                 TimeZone = system.UiTz,
                 Members = members,
@@ -121,7 +121,7 @@ namespace PluralKit.Core
             // Apply system info
             system.Name = data.Name;
             if (data.Description != null) system.Description = data.Description;
-            if (data.Tag != null) system.Tag = data.Tag;
+            if (data.Tag != null) system.TagSuffix = data.Tag;
             if (data.AvatarUrl != null) system.AvatarUrl = data.AvatarUrl;
             if (data.TimeZone != null) system.UiTz = data.TimeZone ?? "UTC";
             await _data.SaveSystem(system);

--- a/PluralKit.Core/Services/PostgresDataStore.cs
+++ b/PluralKit.Core/Services/PostgresDataStore.cs
@@ -85,7 +85,7 @@ namespace PluralKit.Core {
 
         public async Task SaveSystem(PKSystem system) {
             using (var conn = await _conn.Obtain())
-                await conn.ExecuteAsync("update systems set name = @Name, description = @Description, tag = @Tag, avatar_url = @AvatarUrl, token = @Token, ui_tz = @UiTz, description_privacy = @DescriptionPrivacy, member_list_privacy = @MemberListPrivacy, front_privacy = @FrontPrivacy, front_history_privacy = @FrontHistoryPrivacy, pings_enabled = @PingsEnabled where id = @Id", system);
+                await conn.ExecuteAsync("update systems set name = @Name, description = @Description, tag_suffix = @TagSuffix, tag_prefix = @TagPrefix, avatar_url = @AvatarUrl, token = @Token, ui_tz = @UiTz, description_privacy = @DescriptionPrivacy, member_list_privacy = @MemberListPrivacy, front_privacy = @FrontPrivacy, front_history_privacy = @FrontHistoryPrivacy, pings_enabled = @PingsEnabled where id = @Id", system);
 
             _logger.Information("Updated system {@System}", system);
         }


### PR DESCRIPTION
This pr adds the feature to allow system tags to have a prefix and suffix, rather then just being a suffix to the name.
It also adds the ability to not have white space between the name and tag
and finally it maintains a legacy version where one does not need to define a prefix, or have the separator ("text" is the separator, in order to make it easier so users don't have to remember a new one)

tbh I don't expect this one to be merged but I thought it would be fun to have and create, and the pr exists in case you feel this way too

also ignore the "5 behind 7 ahead" it is actually only 2 ahead but git is weird)