### PR TITLE
Make MessageContext null when author has no account

### DIFF
--- a/PluralKit.Bot/Handlers/MessageCreated.cs
+++ b/PluralKit.Bot/Handlers/MessageCreated.cs
@@ -70,7 +70,7 @@ namespace PluralKit.Bot
         private async ValueTask<bool> TryHandleLogClean(MessageCreateEventArgs evt, MessageContext ctx)
         {
             if (!evt.Message.Author.IsBot || evt.Message.Channel.Type != ChannelType.Text ||
-                !ctx.LogCleanupEnabled) return false;
+                ctx == null || !ctx.LogCleanupEnabled) return false;
 
             await _loggerClean.HandleLoggerBotCleanup(evt.Message);
             return true;
@@ -99,7 +99,7 @@ namespace PluralKit.Bot
 
             try
             {
-                var system = ctx.SystemId != null ? await _db.Execute(c => c.QuerySystem(ctx.SystemId.Value)) : null;
+                var system = ctx?.SystemId != null ? await _db.Execute(c => c.QuerySystem(ctx.SystemId.Value)) : null;
                 await _tree.ExecuteCommand(new Context(_services, evt.Client, evt.Message, argPos, system, ctx));
             }
             catch (PKError)
@@ -113,6 +113,7 @@ namespace PluralKit.Bot
 
         private async ValueTask<bool> TryHandleProxy(MessageCreateEventArgs evt, MessageContext ctx)
         {
+            if (ctx == null) return false;
             try
             {
                 return await _proxy.HandleIncomingMessage(evt.Message, ctx, allowAutoproxy: true);

--- a/PluralKit.Core/Database/Functions/DatabaseFunctionsExt.cs
+++ b/PluralKit.Core/Database/Functions/DatabaseFunctionsExt.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Data;
 using System.Threading.Tasks;
 
@@ -10,7 +10,7 @@ namespace PluralKit.Core
     {
         public static Task<MessageContext> QueryMessageContext(this IPKConnection conn, ulong account, ulong guild, ulong channel)
         {
-            return conn.QueryFirstAsync<MessageContext>("message_context", 
+            return conn.QueryFirstOrDefaultAsync<MessageContext>("message_context", 
                 new { account_id = account, guild_id = guild, channel_id = channel }, 
                 commandType: CommandType.StoredProcedure);
         }  


### PR DESCRIPTION
This PR fixes an error that caused PluralKit to repeat a message for the same error indefinitely when a message is sent by an author without an account. This error was only reproducible after attempting to test with a fresh database.