### PR TITLE
Feature - display name as a member argument

### DIFF
--- a/PluralKit.Bot/CommandSystem/Context.cs
+++ b/PluralKit.Bot/CommandSystem/Context.cs
@@ -188,10 +188,11 @@ namespace PluralKit.Bot
         {
             var input = PeekArgument();
 
-            // Member references can have one or two forms, depending on
+            // Member references can have one of three forms, depending on
             // whether you're in a system or not:
             // - A member hid
             // - A textual name of a member *in your own system*
+            // - a textual display name of a member *in your own system*
 
             // First, if we have a system, try finding by member name in system
             if (_senderSystem != null && await _data.GetMemberByName(_senderSystem, input) is PKMember memberByName)
@@ -200,6 +201,10 @@ namespace PluralKit.Bot
             // Then, try member HID parsing:
             if (await _data.GetMemberByHid(input) is PKMember memberByHid)
                 return memberByHid;
+
+            // And if that again fails, we try finding a member with a display name matching the argument from the system
+            if (_senderSystem != null && await _data.GetMemberByDisplayName(_senderSystem, input) is PKMember memberByDisplayName)
+                return memberByDisplayName;
             
             // We didn't find anything, so we return null.
             return null;

--- a/PluralKit.Core/Services/IDataStore.cs
+++ b/PluralKit.Core/Services/IDataStore.cs
@@ -149,6 +149,12 @@ namespace PluralKit.Core {
         /// </para> 
         /// <returns>The <see cref="PKMember"/> with the given name, or null if no member was found.</returns>
         Task<PKMember> GetMemberByName(PKSystem system, string name);
+
+        /// <summary>
+        /// Gets a member by its display name within one system.
+        /// </summary>
+        /// <returns>The <see cref="PKMember"/> with the given name, or null if no member was found.</returns>
+        Task<PKMember> GetMemberByDisplayName(PKSystem system, string name);
         
         /// <summary>
         /// Gets all members inside a given system.

--- a/PluralKit.Core/Services/PostgresDataStore.cs
+++ b/PluralKit.Core/Services/PostgresDataStore.cs
@@ -141,6 +141,12 @@ namespace PluralKit.Core {
                 return await conn.QueryFirstOrDefaultAsync<PKMember>("select * from members where lower(name) = lower(@Name) and system = @SystemID", new { Name = name, SystemID = system.Id });
         }
 
+        public async Task<PKMember> GetMemberByDisplayName(PKSystem system, string name) {
+            // QueryFirst, since members can (in rare cases) share display names
+            using (var conn = await _conn.Obtain())
+                return await conn.QueryFirstOrDefaultAsync<PKMember>("select * from members where lower(display_name) = lower(@Name) and system = @SystemID", new { Name = name, SystemID = system.Id });
+        }
+
         public IAsyncEnumerable<PKMember> GetSystemMembers(PKSystem system, bool orderByName)
         {
             var sql = "select * from members where system = @SystemID";


### PR DESCRIPTION
A small pr that allows member display name to be used as the argument, as both QoL and to increase privacy when using pluralkit with a member with a private name.
This checks for display name matches last, as to not interfere with any existing methods of querying a member