### PR TITLE
Return new member after member PATCH

### DIFF
--- a/PluralKit.API/Controllers/v1/MemberController.cs
+++ b/PluralKit.API/Controllers/v1/MemberController.cs
@@ -88,7 +88,7 @@ namespace PluralKit.API
             }
             
             var newMember = await conn.UpdateMember(member.Id, patch);
-            return Ok(member.ToJson(User.ContextFor(newMember)));
+            return Ok(newMember.ToJson(User.ContextFor(newMember)));
         }
         
         [HttpDelete("{hid}")]


### PR DESCRIPTION
The current code returns the old member, resulting in a response with non-updated data; this pull request is meant to fix that