### PR TITLE
Fix: Escape Backticks

### DIFF
--- a/PluralKit.Bot/Commands/MemberProxy.cs
+++ b/PluralKit.Bot/Commands/MemberProxy.cs
@@ -68,7 +68,7 @@ namespace PluralKit.Bot
                     await ctx.Reply("This member does not have any proxy tags.");
                 else
                 {
-                    var tags = string.Join("\n", target.ProxyTags.Select(t => $"`{t.ProxyString}`"));
+                    var tags = string.Join("\n", target.ProxyTags.Select(t => $"``﻿{t.ProxyString.EscapeBacktickPair()}﻿``"));
                     await ctx.Reply($"This member's proxy tags are:\n{tags}");
                 }
             }
@@ -90,7 +90,7 @@ namespace PluralKit.Bot
                 var patch = new MemberPatch {ProxyTags = Partial<ProxyTag[]>.Present(newTags.ToArray())};
                 await _db.Execute(conn => conn.UpdateMember(target.Id, patch));
 
-                await ctx.Reply($"{Emojis.Success} Added proxy tags `{tagToAdd.ProxyString}`.");
+                await ctx.Reply($"{Emojis.Success} Added proxy tags ``﻿{tagToAdd.ProxyString.EscapeBacktickPair()}﻿``.");
             }
             // Subcommand: "remove"
             else if (ctx.Match("remove", "delete"))
@@ -107,7 +107,7 @@ namespace PluralKit.Bot
                 var patch = new MemberPatch {ProxyTags = Partial<ProxyTag[]>.Present(newTags.ToArray())};
                 await _db.Execute(conn => conn.UpdateMember(target.Id, patch));
 
-                await ctx.Reply($"{Emojis.Success} Removed proxy tags `{tagToRemove.ProxyString}`.");
+                await ctx.Reply($"{Emojis.Success} Removed proxy tags ``﻿{tagToRemove.ProxyString.EscapeBacktickPair()}﻿``.");
             }
             // Subcommand: bare proxy tag given
             else
@@ -131,7 +131,7 @@ namespace PluralKit.Bot
                 var patch = new MemberPatch {ProxyTags = Partial<ProxyTag[]>.Present(newTags)};
                 await _db.Execute(conn => conn.UpdateMember(target.Id, patch));
                 
-                await ctx.Reply($"{Emojis.Success} Member proxy tags set to `{requestedTag.ProxyString}`.");
+                await ctx.Reply($"{Emojis.Success} Member proxy tags set to ``﻿{requestedTag.ProxyString.EscapeBacktickPair()}﻿``.");
             }
         }
     }

--- a/PluralKit.Bot/Errors.cs
+++ b/PluralKit.Bot/Errors.cs
@@ -105,9 +105,9 @@ namespace PluralKit.Bot {
         public static PKError ProxyNameTooShort(string name) => new PKError($"The webhook's name, `{name}`, is shorter than two characters, and thus cannot be proxied. Please change the member name or use a longer system tag.");
         public static PKError ProxyNameTooLong(string name) => new PKError($"The webhook's name, {name}, is too long ({name.Length} > {Limits.MaxProxyNameLength} characters), and thus cannot be proxied. Please change the member name, display name or server display name, or use a shorter system tag.");
 
-        public static PKError ProxyTagAlreadyExists(ProxyTag tagToAdd, PKMember member) => new PKError($"That member already has the proxy tag `{tagToAdd.ProxyString}`. The member currently has these tags: {member.ProxyTagsString()}");
-        public static PKError ProxyTagDoesNotExist(ProxyTag tagToRemove, PKMember member) => new PKError($"That member does not have the proxy tag `{tagToRemove.ProxyString}`. The member currently has these tags: {member.ProxyTagsString()}");
-        public static PKError LegacyAlreadyHasProxyTag(ProxyTag requested, PKMember member) => new PKError($"This member already has more than one proxy tag set: {member.ProxyTagsString()}\nConsider using the `pk;member {member.Hid} proxy add {requested.ProxyString}` command instead.");
+        public static PKError ProxyTagAlreadyExists(ProxyTag tagToAdd, PKMember member) => new PKError($"That member already has the proxy tag ``﻿{tagToAdd.ProxyString.EscapeBacktickPair()}﻿``. The member currently has these tags: {member.ProxyTagsString()}");
+        public static PKError ProxyTagDoesNotExist(ProxyTag tagToRemove, PKMember member) => new PKError($"That member does not have the proxy tag ``﻿{tagToRemove.ProxyString.EscapeBacktickPair()}﻿``. The member currently has these tags: {member.ProxyTagsString()}");
+        public static PKError LegacyAlreadyHasProxyTag(ProxyTag requested, PKMember member) => new PKError($"This member already has more than one proxy tag set: {member.ProxyTagsString()}\nConsider using the ``pk;member {member.Hid} proxy add {requested.ProxyString.EscapeBacktickPair()}﻿`` command instead.");
         public static PKError EmptyProxyTags(PKMember member) => new PKError($"The example proxy `text` is equivalent to having no proxy tags at all, since there are no symbols or brackets on either end. If you'd like to clear your proxy tags, use `pk;member {member.Hid} proxy clear`.");
 
         public static PKError GenericCancelled() => new PKError("Operation cancelled.");

--- a/PluralKit.Bot/Lists/ShortRenderer.cs
+++ b/PluralKit.Bot/Lists/ShortRenderer.cs
@@ -22,7 +22,7 @@ namespace PluralKit.Bot
                     var proxyTagsString = m.ProxyTagsString();
                     if (proxyTagsString.Length > 100) // arbitrary threshold for now, tweak?
                         proxyTagsString = "tags too long, see member card";
-                    return $"[`{m.Hid}`] **{m.NameFor(ctx)}** *({proxyTagsString})*";
+                    return $"[`{m.Hid}`] **{m.NameFor(ctx)}** *(*{proxyTagsString}*)*";
                 }
 
                 return $"[`{m.Hid}`] **{m.NameFor(ctx)}**";

--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -107,7 +107,7 @@ namespace PluralKit.Bot {
             var guildDisplayName = guildSettings?.DisplayName;
             var avatar = guildSettings?.AvatarUrl ?? member.AvatarFor(ctx);
 
-            var proxyTagsStr = string.Join('\n', member.ProxyTags.Select(t => $"`{t.ProxyString}`"));
+            var proxyTagsStr = string.Join('\n', member.ProxyTags.Select(t => $"``﻿{t.ProxyString}﻿``"));
 
             var eb = new DiscordEmbedBuilder()
                 // TODO: add URL of website when that's up

--- a/PluralKit.Bot/Utils/DiscordUtils.cs
+++ b/PluralKit.Bot/Utils/DiscordUtils.cs
@@ -192,10 +192,9 @@ namespace PluralKit.Bot
             else return input;
         }
 
-        public static string EscapeBacktickPair(this string  input){
+        public static string EscapeBacktickPair(this string input){
             Regex pattern = new Regex(@"``", RegexOptions.Multiline);
-            Regex pattern2 = new Regex(@"[*_~>(||)\\]", RegexOptions.Multiline);
-            if(input != null) return pattern2.Replace(pattern.Replace(input, @"`﻿`"), @"\$&");
+            if(input != null) return pattern.Replace(input, @"`‌﻿`");
             else return input;
         }
 

--- a/PluralKit.Bot/Utils/DiscordUtils.cs
+++ b/PluralKit.Bot/Utils/DiscordUtils.cs
@@ -193,8 +193,9 @@ namespace PluralKit.Bot
         }
 
         public static string EscapeBacktickPair(this string input){
-            Regex pattern = new Regex(@"``", RegexOptions.Multiline);
-            if(input != null) return pattern.Replace(input, @"`‌﻿`");
+            Regex doubleBacktick = new Regex(@"``", RegexOptions.Multiline);
+            Regex trippleBacktick = new Regex(@"```", RegexOptions.Multiline);
+            if(input != null) return trippleBacktick.Replace(doubleBacktick.Replace(input, @"`‌﻿`"),@"`‌﻿`﻿`");
             else return input;
         }
 

--- a/PluralKit.Bot/Utils/DiscordUtils.cs
+++ b/PluralKit.Bot/Utils/DiscordUtils.cs
@@ -192,6 +192,13 @@ namespace PluralKit.Bot
             else return input;
         }
 
+        public static string EscapeBacktickPair(this string  input){
+            Regex pattern = new Regex(@"``", RegexOptions.Multiline);
+            Regex pattern2 = new Regex(@"[*_~>(||)\\]", RegexOptions.Multiline);
+            if(input != null) return pattern2.Replace(pattern.Replace(input, @"`﻿`"), @"\$&");
+            else return input;
+        }
+
         public static Task<DiscordUser> GetUser(this DiscordRestClient client, ulong id) => 
             WrapDiscordCall(client.GetUserAsync(id));
 

--- a/PluralKit.Bot/Utils/DiscordUtils.cs
+++ b/PluralKit.Bot/Utils/DiscordUtils.cs
@@ -194,8 +194,8 @@ namespace PluralKit.Bot
 
         public static string EscapeBacktickPair(this string input){
             Regex doubleBacktick = new Regex(@"``", RegexOptions.Multiline);
-            Regex trippleBacktick = new Regex(@"```", RegexOptions.Multiline);
-            if(input != null) return trippleBacktick.Replace(doubleBacktick.Replace(input, @"`‌﻿`"),@"`‌﻿`﻿`");
+            //Run twice to catch any pairs that are created from the first pass, pairs shouldn't be created in the second as they are created from odd numbers of backticks, even numbers are all caught on the first pass
+            if(input != null) return doubleBacktick.Replace(doubleBacktick.Replace(input, @"`‌﻿`"),@"`‌﻿`");
             else return input;
         }
 

--- a/PluralKit.Bot/Utils/MiscUtils.cs
+++ b/PluralKit.Bot/Utils/MiscUtils.cs
@@ -14,7 +14,7 @@ using PluralKit.Core;
 namespace PluralKit.Bot
 {
     public static class MiscUtils {
-        public static string ProxyTagsString(this PKMember member) => string.Join(", ", member.ProxyTags.Select(t => $"`{t.ProxyString.EscapeMarkdown()}`"));
+        public static string ProxyTagsString(this PKMember member) => string.Join(", ", member.ProxyTags.Select(t => $"``﻿{t.ProxyString.EscapeBacktickPair()}﻿``"));
         
         public static bool IsOurProblem(this Exception e)
         {


### PR DESCRIPTION
This fix escapes backticks in proxy tags so the list isn't messed up, and also adds a small formatting change to allow discord to manage the markdown escape in inline code, rather then pluralkit having to do it to prevent breaks