### PR TITLE
Fix URL handling when the filename contains multiple known extensions

### DIFF
--- a/PluralKit.Bot/Commands/Avatars/ContextAvatarExt.cs
+++ b/PluralKit.Bot/Commands/Avatars/ContextAvatarExt.cs
@@ -14,7 +14,7 @@ namespace PluralKit.Bot
         // Rewrite cdn.discordapp.com URLs to media.discordapp.net for jpg/png files
         // This lets us add resizing parameters to "borrow" their media proxy server to downsize the image
         // which in turn makes it more likely to be underneath the size limit!
-        private static readonly Regex DiscordCdnUrl = new Regex(@"^https?://(?:cdn\.discordapp\.com|media\.discordapp\.net)/attachments/(\d{17,19})/(\d{17,19})/([^\.?/]+)\.(png|jpg|jpeg).*");
+        private static readonly Regex DiscordCdnUrl = new Regex(@"^https?://(?:cdn\.discordapp\.com|media\.discordapp\.net)/attachments/(\d{17,19})/(\d{17,19})/([^/\\&\?]+)\.(png|jpg|jpeg)(\?.*)?$");
         private static readonly string DiscordMediaUrlReplacement = "https://media.discordapp.net/attachments/$1/$2/$3.$4?width=256&height=256";
         
         public static async Task<ParsedImage?> MatchImage(this Context ctx)
@@ -39,7 +39,6 @@ namespace PluralKit.Bot
 
                 if (uri.Scheme != "http" && uri.Scheme != "https")
                     throw Errors.InvalidUrl(arg);
-
                 return new ParsedImage {Url = TryRewriteCdnUrl(uri.ToString()), Source = AvatarSource.Url};
             }
             


### PR DESCRIPTION
Example: `image.jpeg-32.jpg` gets matched as `image.jpeg`

I think this regex should work, although I wonder if there's anything else that can be after the filename in the URL other than a `?`