### PR TITLE
Add -yes flag to CheckYesNo

### DIFF
--- a/PluralKit.Bot/Commands/ImportExport.cs
+++ b/PluralKit.Bot/Commands/ImportExport.cs
@@ -76,7 +76,7 @@ namespace PluralKit.Bot
                                     issueStr +=
                                         "\n- PluralKit does not support per-member system tags. Since you had multiple members with distinct tags, those tags will be applied to the members' *display names*/nicknames instead.";
 
-                                var msg = await ctx.Reply($"{issueStr}\n\nDo you want to proceed with the import?");
+                                var msg = $"{issueStr}\n\nDo you want to proceed with the import?";
                                 if (!await ctx.PromptYesNo(msg)) throw Errors.ImportCancelled;
                             }
                             
@@ -93,7 +93,7 @@ namespace PluralKit.Bot
 
                     if (data.LinkedAccounts != null && !data.LinkedAccounts.Contains(ctx.Author.Id))
                     {
-                        var msg = await ctx.Reply($"{Emojis.Warn} You seem to importing a system profile belonging to another account. Are you sure you want to proceed?");
+                        var msg = $"{Emojis.Warn} You seem to importing a system profile belonging to another account. Are you sure you want to proceed?";
                         if (!await ctx.PromptYesNo(msg)) throw Errors.ImportCancelled;
                     }
 

--- a/PluralKit.Bot/Commands/Member.cs
+++ b/PluralKit.Bot/Commands/Member.cs
@@ -28,7 +28,7 @@ namespace PluralKit.Bot
             // Warn if there's already a member by this name
             var existingMember = await _data.GetMemberByName(ctx.System, memberName);
             if (existingMember != null) {
-                var msg = await ctx.Reply($"{Emojis.Warn} You already have a member in your system with the name \"{existingMember.NameFor(ctx)}\" (with ID `{existingMember.Hid}`). Do you want to create another member with the same name?");
+                var msg = $"{Emojis.Warn} You already have a member in your system with the name \"{existingMember.NameFor(ctx)}\" (with ID `{existingMember.Hid}`). Do you want to create another member with the same name?";
                 if (!await ctx.PromptYesNo(msg)) throw new PKError("Member creation cancelled.");
             }
 

--- a/PluralKit.Bot/Commands/MemberEdit.cs
+++ b/PluralKit.Bot/Commands/MemberEdit.cs
@@ -37,7 +37,7 @@ namespace PluralKit.Bot
             // Warn if there's already a member by this name
             var existingMember = await _data.GetMemberByName(ctx.System, newName);
             if (existingMember != null) {
-                var msg = await ctx.Reply($"{Emojis.Warn} You already have a member in your system with the name \"{existingMember.NameFor(ctx)}\" (`{existingMember.Hid}`). Do you want to rename this member to that name too?");
+                var msg = $"{Emojis.Warn} You already have a member in your system with the name \"{existingMember.NameFor(ctx)}\" (`{existingMember.Hid}`). Do you want to rename this member to that name too?";
                 if (!await ctx.PromptYesNo(msg)) throw new PKError("Member renaming cancelled.");
             }
 

--- a/PluralKit.Bot/Commands/MemberProxy.cs
+++ b/PluralKit.Bot/Commands/MemberProxy.cs
@@ -39,8 +39,7 @@ namespace PluralKit.Bot
                 if (conflicts.Count <= 0) return true;
 
                 var conflictList = conflicts.Select(m => $"- **{m.NameFor(ctx)}**");
-                var msg = await ctx.Reply(
-                    $"{Emojis.Warn} The following members have conflicting proxy tags:\n{string.Join('\n', conflictList)}\nDo you want to proceed anyway?");
+                var msg = $"{Emojis.Warn} The following members have conflicting proxy tags:\n{string.Join('\n', conflictList)}\nDo you want to proceed anyway?";
                 return await ctx.PromptYesNo(msg);
             }
             
@@ -50,8 +49,7 @@ namespace PluralKit.Bot
                 // If we already have multiple tags, this would clear everything, so prompt that
                 if (target.ProxyTags.Count > 1)
                 {
-                    var msg = await ctx.Reply(
-                        $"{Emojis.Warn} You already have multiple proxy tags set: {target.ProxyTagsString()}\nDo you want to clear them all?");
+                    var msg = $"{Emojis.Warn} You already have multiple proxy tags set: {target.ProxyTagsString()}\nDo you want to clear them all?";
                     if (!await ctx.PromptYesNo(msg))
                         throw Errors.GenericCancelled();
                 }
@@ -119,7 +117,7 @@ namespace PluralKit.Bot
                 // already more than one proxy tag.
                 if (target.ProxyTags.Count > 1)
                 {
-                    var msg = await ctx.Reply($"This member already has more than one proxy tag set: {target.ProxyTagsString()}\nDo you want to replace them?");
+                    var msg = $"This member already has more than one proxy tag set: {target.ProxyTagsString()}\nDo you want to replace them?";
                     if (!await ctx.PromptYesNo(msg))
                         throw Errors.GenericCancelled();
                 }

--- a/PluralKit.Bot/Commands/Switch.cs
+++ b/PluralKit.Bot/Commands/Switch.cs
@@ -95,7 +95,7 @@ namespace PluralKit.Bot
             var newSwitchDeltaStr = (SystemClock.Instance.GetCurrentInstant() - time.ToInstant()).FormatDuration();
             
             // yeet
-            var msg = await ctx.Reply($"{Emojis.Warn} This will move the latest switch ({lastSwitchMemberStr}) from {lastSwitchTimeStr} ({lastSwitchDeltaStr} ago) to {newSwitchTimeStr} ({newSwitchDeltaStr} ago). Is this OK?");
+            var msg = $"{Emojis.Warn} This will move the latest switch ({lastSwitchMemberStr}) from {lastSwitchTimeStr} ({lastSwitchDeltaStr} ago) to {newSwitchTimeStr} ({newSwitchDeltaStr} ago). Is this OK?";
             if (!await ctx.PromptYesNo(msg)) throw Errors.SwitchMoveCancelled;
             
             // aaaand *now* we do the move
@@ -110,7 +110,7 @@ namespace PluralKit.Bot
             if (ctx.Match("all", "clear"))
             {
                 // Subcommand: "delete all"
-                var purgeMsg = await ctx.Reply($"{Emojis.Warn} This will delete *all registered switches* in your system. Are you sure you want to proceed?");
+                var purgeMsg = $"{Emojis.Warn} This will delete *all registered switches* in your system. Are you sure you want to proceed?";
                 if (!await ctx.PromptYesNo(purgeMsg))
                     throw Errors.GenericCancelled();
                 await _data.DeleteAllSwitches(ctx.System);
@@ -126,19 +126,17 @@ namespace PluralKit.Bot
             var lastSwitchMemberStr = string.Join(", ", await lastSwitchMembers.Select(m => m.NameFor(ctx)).ToListAsync());
             var lastSwitchDeltaStr = (SystemClock.Instance.GetCurrentInstant() - lastTwoSwitches[0].Timestamp).FormatDuration();
 
-            DiscordMessage msg;
+            string msg;
             if (lastTwoSwitches.Count == 1)
             {
-                msg = await ctx.Reply(
-                    $"{Emojis.Warn} This will delete the latest switch ({lastSwitchMemberStr}, {lastSwitchDeltaStr} ago). You have no other switches logged. Is this okay?");
+                msg = $"{Emojis.Warn} This will delete the latest switch ({lastSwitchMemberStr}, {lastSwitchDeltaStr} ago). You have no other switches logged. Is this okay?";
             }
             else
             {
                 var secondSwitchMembers = _data.GetSwitchMembers(lastTwoSwitches[1]);
                 var secondSwitchMemberStr = string.Join(", ", await secondSwitchMembers.Select(m => m.NameFor(ctx)).ToListAsync());
                 var secondSwitchDeltaStr = (SystemClock.Instance.GetCurrentInstant() - lastTwoSwitches[1].Timestamp).FormatDuration();
-                msg = await ctx.Reply(
-                    $"{Emojis.Warn} This will delete the latest switch ({lastSwitchMemberStr}, {lastSwitchDeltaStr} ago). The next latest switch is {secondSwitchMemberStr} ({secondSwitchDeltaStr} ago). Is this okay?");
+                msg = $"{Emojis.Warn} This will delete the latest switch ({lastSwitchMemberStr}, {lastSwitchDeltaStr} ago). The next latest switch is {secondSwitchMemberStr} ({secondSwitchDeltaStr} ago). Is this okay?";
             }
 
             if (!await ctx.PromptYesNo(msg)) throw Errors.SwitchDeleteCancelled;

--- a/PluralKit.Bot/Commands/SystemEdit.cs
+++ b/PluralKit.Bot/Commands/SystemEdit.cs
@@ -249,8 +249,7 @@ namespace PluralKit.Bot
             if (zone == null) throw Errors.InvalidTimeZone(zoneStr);
 
             var currentTime = SystemClock.Instance.GetCurrentInstant().InZone(zone);
-            var msg = await ctx.Reply(
-                $"This will change the system time zone to **{zone.Id}**. The current time is **{currentTime.FormatZoned()}**. Is this correct?");
+            var msg = $"This will change the system time zone to **{zone.Id}**. The current time is **{currentTime.FormatZoned()}**. Is this correct?";
             if (!await ctx.PromptYesNo(msg)) throw Errors.TimezoneChangeCancelled;
             
             var patch = new SystemPatch {UiTz = zone.Id};

--- a/PluralKit.Bot/Commands/SystemLink.cs
+++ b/PluralKit.Bot/Commands/SystemLink.cs
@@ -27,9 +27,9 @@ namespace PluralKit.Bot
             var existingAccount = await _data.GetSystemByAccount(account.Id);
             if (existingAccount != null) throw Errors.AccountInOtherSystem(existingAccount); 
 
-            var msg = await ctx.Reply($"{account.Mention}, please confirm the link by clicking the {Emojis.Success} reaction on this message.",
-                mentions: new IMention[] { new UserMention(account) });
-            if (!await ctx.PromptYesNo(msg, user: account)) throw Errors.MemberLinkCancelled;
+            var msg = $"{account.Mention}, please confirm the link by clicking the {Emojis.Success} reaction on this message.";
+            var mentions = new IMention[] { new UserMention(account) };
+            if (!await ctx.PromptYesNo(msg, user: account, mentions: mentions)) throw Errors.MemberLinkCancelled;
             await _data.AddAccount(ctx.System, account.Id);
             await ctx.Reply($"{Emojis.Success} Account linked to system.");
         }
@@ -48,8 +48,7 @@ namespace PluralKit.Bot
             if (!accountIds.Contains(id)) throw Errors.AccountNotLinked;
             if (accountIds.Count == 1) throw Errors.UnlinkingLastAccount;
             
-            var msg = await ctx.Reply(
-                $"Are you sure you want to unlink <@{id}> from your system?");
+            var msg = $"Are you sure you want to unlink <@{id}> from your system?";
             if (!await ctx.PromptYesNo(msg)) throw Errors.MemberUnlinkCancelled;
 
             await _data.RemoveAccount(ctx.System, id);

--- a/PluralKit.Bot/Utils/ContextUtils.cs
+++ b/PluralKit.Bot/Utils/ContextUtils.cs
@@ -17,8 +17,11 @@ using PluralKit.Core;
 
 namespace PluralKit.Bot {
     public static class ContextUtils {
-        public static async Task<bool> PromptYesNo(this Context ctx, DiscordMessage message, DiscordUser user = null, Duration? timeout = null)
+        public static async Task<bool> PromptYesNo(this Context ctx, String msgString, DiscordUser user = null, Duration? timeout = null, IEnumerable<IMention> mentions = null)
         {
+            DiscordMessage message;
+            if (ctx.MatchFlag("y", "yes")) return true;
+            else message = await ctx.Reply(msgString, mentions: mentions);
             var cts = new CancellationTokenSource();
             if (user == null) user = ctx.Author;
             if (timeout == null) timeout = Duration.FromMinutes(5);


### PR DESCRIPTION
The `-yes` or `-y` flags will skip asking the user for confirmation when doing certain actions such as deleting switches. Note, this does not skip confirmation where an ID input is required (deleting member or system).