### PR TITLE
Remove "remove" keyword from MatchClear

### DIFF
--- a/PluralKit.Bot/CommandSystem/ContextArgumentsExt.cs
+++ b/PluralKit.Bot/CommandSystem/ContextArgumentsExt.cs
@@ -61,7 +61,7 @@ namespace PluralKit.Bot
         }
 
         public static bool MatchClear(this Context ctx) =>
-            ctx.Match("clear", "remove", "reset") || ctx.MatchFlag("c", "clear");
+            ctx.Match("clear", "reset") || ctx.MatchFlag("c", "clear");
 
         public static async Task<List<PKMember>> ParseMemberList(this Context ctx, SystemId? restrictToSystem)
         {


### PR DESCRIPTION
Fixes commands that use `remove` as a keyword for removing a single object (such as removing a proxy tag from a member).