### PR TITLE
Feature/default private membercards

### DIFF
--- a/PluralKit.Bot/Commands/Cards/CardOptions.cs
+++ b/PluralKit.Bot/Commands/Cards/CardOptions.cs
@@ -19,7 +19,7 @@ namespace PluralKit.Bot
             var str = new StringBuilder();
             str.Append(PrivacyFilter switch
             {
-                PrivacyLevel.Private => ", showing only private members",
+                null => "including private feilds",
                 PrivacyLevel.Public => "", // (default, no extra line needed)
                 _ => new ArgumentOutOfRangeException($"Couldn't find readable string for privacy filter {PrivacyFilter}")
             });

--- a/PluralKit.Bot/Commands/Cards/CardOptions.cs
+++ b/PluralKit.Bot/Commands/Cards/CardOptions.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using NodaTime;
+
+using PluralKit.Core;
+
+#nullable enable
+namespace PluralKit.Bot
+{
+    public class CardOptions
+    {
+
+        public PrivacyLevel? PrivacyFilter { get; set; } = PrivacyLevel.Public;
+
+        public string createFooter() {
+            var str = new StringBuilder();
+            str.Append(PrivacyFilter switch
+            {
+                PrivacyLevel.Private => ", showing only private members",
+                PrivacyLevel.Public => "", // (default, no extra line needed)
+                _ => new ArgumentOutOfRangeException($"Couldn't find readable string for privacy filter {PrivacyFilter}")
+            });
+            return(str.ToString());
+        }
+    }
+}

--- a/PluralKit.Bot/Commands/Cards/ContextCardExt.cs
+++ b/PluralKit.Bot/Commands/Cards/ContextCardExt.cs
@@ -15,7 +15,7 @@ namespace PluralKit.Bot
 
             // PERM CHECK: If we're trying to access private fields of another system, error
             if (p.PrivacyFilter != PrivacyLevel.Public && lookupCtx != LookupContext.ByOwner)
-                throw new PKError("You cannot look up private fields of another system's member.");
+                throw new PKError("You cannot look up private fields of another system.");
             
             // Done!
             return p;

--- a/PluralKit.Bot/Commands/Cards/ContextCardExt.cs
+++ b/PluralKit.Bot/Commands/Cards/ContextCardExt.cs
@@ -1,0 +1,24 @@
+using PluralKit.Core;
+
+
+namespace PluralKit.Bot
+{
+    public static class ContextCardExt
+    {
+        public static CardOptions ParseCardOptions(this Context ctx, LookupContext lookupCtx)
+        {
+            var p = new CardOptions();
+
+            // Privacy filter (default is public fields only)
+            if (ctx.MatchFlag("a", "all")) p.PrivacyFilter = null; 
+            if (ctx.MatchFlag("s","safe")) p.PrivacyFilter = PrivacyLevel.Public;
+
+            // PERM CHECK: If we're trying to access private fields of another system, error
+            if (p.PrivacyFilter != PrivacyLevel.Public && lookupCtx != LookupContext.ByOwner)
+                throw new PKError("You cannot look up private fields of another system's member.");
+            
+            // Done!
+            return p;
+        }
+    }
+}

--- a/PluralKit.Bot/Commands/Cards/ContextCardExt.cs
+++ b/PluralKit.Bot/Commands/Cards/ContextCardExt.cs
@@ -10,8 +10,8 @@ namespace PluralKit.Bot
             var p = new CardOptions();
 
             // Privacy filter (default is public fields only)
-            if (ctx.MatchFlag("a", "all")) p.PrivacyFilter = null; 
-            if (ctx.MatchFlag("s","safe")) p.PrivacyFilter = PrivacyLevel.Public;
+            if (ctx.MatchFlag("a", "all", "private")) p.PrivacyFilter = null; 
+            if (ctx.MatchFlag("s", "safe", "public")) p.PrivacyFilter = PrivacyLevel.Public;
 
             // PERM CHECK: If we're trying to access private fields of another system, error
             if (p.PrivacyFilter != PrivacyLevel.Public && lookupCtx != LookupContext.ByOwner)

--- a/PluralKit.Bot/Commands/Member.cs
+++ b/PluralKit.Bot/Commands/Member.cs
@@ -65,14 +65,16 @@ namespace PluralKit.Bot
             if (members == null || !members.Any())
                 throw Errors.NoMembersError;
             var randInt = randGen.Next(members.Count);
-            await ctx.Reply(embed: await _embeds.CreateMemberEmbed(ctx.System, members[randInt], ctx.Guild, ctx.LookupContextFor(ctx.System)));
+            var opts = ctx.ParseCardOptions(ctx.LookupContextFor(ctx.System));
+            await ctx.Reply(embed: await _embeds.CreateMemberEmbed(ctx.System, members[randInt], ctx.Guild, ctx.LookupContextFor(ctx.System), opts));
         }
 
         public async Task ViewMember(Context ctx, PKMember target)
         {
             
             var system = await _db.Execute(c => c.QuerySystem(target.System));
-            await ctx.Reply(embed: await _embeds.CreateMemberEmbed(system, target, ctx.Guild, ctx.LookupContextFor(system)));
+            var opts = ctx.ParseCardOptions(ctx.LookupContextFor(system));
+            await ctx.Reply(embed: await _embeds.CreateMemberEmbed(system, target, ctx.Guild, ctx.LookupContextFor(system), opts));
         }
     }
 }

--- a/PluralKit.Bot/Commands/System.cs
+++ b/PluralKit.Bot/Commands/System.cs
@@ -18,7 +18,8 @@ namespace PluralKit.Bot
         public async Task Query(Context ctx, PKSystem system) {
             if (system == null) throw Errors.NoSystemError;
 
-            await ctx.Reply(embed: await _embeds.CreateSystemEmbed(ctx.Shard, system, ctx.LookupContextFor(system)));
+            var opts = ctx.ParseCardOptions(ctx.LookupContextFor(system));
+            await ctx.Reply(embed: await _embeds.CreateSystemEmbed(ctx.Shard, system, ctx.LookupContextFor(system), opts));
         }
 
         public async Task New(Context ctx)

--- a/PluralKit.Bot/Handlers/ReactionAdded.cs
+++ b/PluralKit.Bot/Handlers/ReactionAdded.cs
@@ -93,7 +93,7 @@ namespace PluralKit.Bot
             var member = await evt.Guild.GetMember(evt.User.Id);
             try
             {
-                await member.SendMessageAsync(embed: await _embeds.CreateMemberEmbed(msg.System, msg.Member, evt.Guild, LookupContext.ByNonOwner));
+                await member.SendMessageAsync(embed: await _embeds.CreateMemberEmbed(msg.System, msg.Member, evt.Guild, LookupContext.ByNonOwner, new CardOptions()));
                 await member.SendMessageAsync(embed: await _embeds.CreateMessageInfoEmbed(evt.Client, msg));
             }
             catch (UnauthorizedException) { } // No permissions to DM, can't check for this :(

--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -28,9 +28,14 @@ namespace PluralKit.Bot {
 
 
         
-        public async Task<DiscordEmbed> CreateSystemEmbed(DiscordClient client, PKSystem system, LookupContext ctx)
+        public async Task<DiscordEmbed> CreateSystemEmbed(DiscordClient client, PKSystem system, LookupContext ctx, CardOptions opts)
         {
             await using var conn = await _db.Obtain();
+
+            if(opts.PrivacyFilter == PrivacyLevel.Public)
+            {
+                ctx = LookupContext.ByNonOwner;
+            }
             
             // Fetch/render info for all accounts simultaneously
             var accounts = await conn.GetLinkedAccounts(system.Id);
@@ -41,7 +46,7 @@ namespace PluralKit.Bot {
                 .WithColor(DiscordUtils.Gray)
                 .WithTitle(system.Name ?? null)
                 .WithThumbnail(system.AvatarUrl)
-                .WithFooter($"System ID: {system.Hid} | Created on {system.Created.FormatZoned(system)}");
+                .WithFooter($"System ID: {system.Hid} | Created on {system.Created.FormatZoned(system)}{opts.createFooter()}");
  
             var latestSwitch = await _data.GetLatestSwitch(system.Id);
             if (latestSwitch != null && system.FrontPrivacy.CanAccess(ctx))

--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -82,10 +82,15 @@ namespace PluralKit.Bot {
                 .Build();
         }
 
-        public async Task<DiscordEmbed> CreateMemberEmbed(PKSystem system, PKMember member, DiscordGuild guild, LookupContext ctx)
+        public async Task<DiscordEmbed> CreateMemberEmbed(PKSystem system, PKMember member, DiscordGuild guild, LookupContext ctx, CardOptions opts)
         {
 
             // string FormatTimestamp(Instant timestamp) => DateTimeFormats.ZonedDateTimeFormat.Format(timestamp.InZone(system.Zone));
+
+            if(opts.PrivacyFilter == PrivacyLevel.Public)
+            {
+                ctx = LookupContext.ByNonOwner;
+            }
 
             var name = member.NameFor(ctx);
             if (system.Name != null) name = $"{name} ({system.Name})";
@@ -114,7 +119,7 @@ namespace PluralKit.Bot {
                 .WithAuthor(name, iconUrl: DiscordUtils.WorkaroundForUrlBug(avatar))
                 // .WithColor(member.ColorPrivacy.CanAccess(ctx) ? color : DiscordUtils.Gray)
                 .WithColor(color)
-                .WithFooter($"System ID: {system.Hid} | Member ID: {member.Hid} {(member.MetadataPrivacy.CanAccess(ctx) ? $"| Created on {member.Created.FormatZoned(system)}":"")}");
+                .WithFooter($"System ID: {system.Hid} | Member ID: {member.Hid} {(member.MetadataPrivacy.CanAccess(ctx) ? $"| Created on {member.Created.FormatZoned(system)}":"")}{opts.createFooter()}");
 
             var description = "";
             if (member.MemberVisibility == PrivacyLevel.Private) description += "*(this member is hidden)*\n";

--- a/docs/2-user-guide.md
+++ b/docs/2-user-guide.md
@@ -432,7 +432,7 @@ At the moment, there are four aspects of system privacy that can be configured.
 - Front history
 - Member list
 
-Each of these can be set to **public** or **private**. When set to **public**, anyone who queries your system (by account or system ID, or through the API), will see this information. When set to **private**, the information will only be shown when *you yourself* query the information. The cards will still be displayed in the channel the commands are run in, so it's still your responsibility not to pull up information in servers where you don't want it displayed.
+Each of these can be set to **public** or **private**. When set to **public**, anyone who queries your system (by account or system ID, or through the API), will see this information. When set to **private**, the information will only be shown when *you yourself* query the information with the -all flag, for example `pk;system -all`. The cards will still be displayed in the channel the commands are run in, so it's still your responsibility not to pull up information in servers where you don't want it displayed.
 
 To update your system privacy settings, use the following commands:
 
@@ -459,7 +459,7 @@ There are also seven options for configuring member privacy;
 - Metadata *(message count, creation date, etc)*
 - Visibility *(whether the member shows up in member lists)*
 
-As with system privacy, each can be set to **public** or **private**. The same rules apply for how they are shown, too. When set to **public**, anyone who queries your system (by account or system ID, or through the API), will see this information. When set to **private**, the information will only be shown when *you yourself* query the information. The cards will still be displayed in the channel the commands are run in, so it's still your responsibility not to pull up information in servers where you don't want it displayed.
+As with system privacy, each can be set to **public** or **private**. The same rules apply for how they are shown, too. When set to **public**, anyone who queries your system (by account or system ID, or through the API), will see this information. When set to **private**, the information will only be shown when *you yourself* query the information with the -all flag, for example `pk;member <member> -all`. The cards will still be displayed in the channel the commands are run in, so it's still your responsibility not to pull up information in servers where you don't want it displayed.
 
 However, there are two catches:
 - When the **name** is set to private, it will be replaced by the member's **display name**, but only if they have one! If the member has no display name, **name privacy will not do anything**. PluralKit still needs some way to refer to a member by name :) 


### PR DESCRIPTION
Probably a little hacky but a neat and small modification to have member and system cards display only public information unless the flags `-all`, `-a`, or `-private` are used.