### PR TITLE
Fix pk;msg errors across shards

### DIFF
--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -158,8 +158,7 @@ namespace PluralKit.Bot {
         public async Task<DiscordEmbed> CreateMessageInfoEmbed(DiscordClient client, FullMessage msg)
         {
             var ctx = LookupContext.ByNonOwner;
-            
-            var channel = await client.GetChannel(msg.Message.Channel);
+            var channel = await _client.GetChannel(msg.Message.Channel);
             var serverMsg = channel != null ? await channel.GetMessage(msg.Message.Mid) : null;
 
             // Need this whole dance to handle cases where:


### PR DESCRIPTION
It appears the shards' guild cache *is* externally accessible - so we can just look up a guild there instead of using GetGuild (which would generate an API call per shard until we find the correct one).