### PR TITLE
Fix doubleBacktick replacing

### DIFF
--- a/PluralKit.Bot/Utils/DiscordUtils.cs
+++ b/PluralKit.Bot/Utils/DiscordUtils.cs
@@ -212,7 +212,7 @@ namespace PluralKit.Bot
         public static string EscapeBacktickPair(this string input){
             Regex doubleBacktick = new Regex(@"``", RegexOptions.Multiline);
             //Run twice to catch any pairs that are created from the first pass, pairs shouldn't be created in the second as they are created from odd numbers of backticks, even numbers are all caught on the first pass
-            if(input != null) return doubleBacktick.Replace(doubleBacktick.Replace(input, @"`‌﻿`"),@"`‌﻿`");
+            if(input != null) return doubleBacktick.Replace(doubleBacktick.Replace(input, "`‌\ufeff`"),"`‌\ufeff`");
             else return input;
         }
 

--- a/PluralKit.Bot/Utils/DiscordUtils.cs
+++ b/PluralKit.Bot/Utils/DiscordUtils.cs
@@ -212,7 +212,7 @@ namespace PluralKit.Bot
         public static string EscapeBacktickPair(this string input){
             Regex doubleBacktick = new Regex(@"``", RegexOptions.Multiline);
             //Run twice to catch any pairs that are created from the first pass, pairs shouldn't be created in the second as they are created from odd numbers of backticks, even numbers are all caught on the first pass
-            if(input != null) return doubleBacktick.Replace(doubleBacktick.Replace(input, @"`‌ `"),@"`‌﻿`");
+            if(input != null) return doubleBacktick.Replace(doubleBacktick.Replace(input, @"`‌﻿`"),@"`‌﻿`");
             else return input;
         }
 


### PR DESCRIPTION
the first run of doubleBacktick.replace has a visible space instead of a zero width space. this copy pastes the second run's replace string into the first run so the visible output is unchanged.