### PR TITLE
fix GetChannel where guildId is not passed

### DIFF
--- a/PluralKit.Bot/Utils/DiscordUtils.cs
+++ b/PluralKit.Bot/Utils/DiscordUtils.cs
@@ -271,8 +271,8 @@ namespace PluralKit.Bot
         {
             // we need to know the channel's guild ID to get the cached guild object, so we grab it from the API
             if (guildId == null) {
-                var guild = await WrapDiscordCall(client.ShardClients.Values.FirstOrDefault().GetChannelAsync(id));
-                if (guild != null) guildId = guild.Id;
+                var channel = await WrapDiscordCall(client.ShardClients.Values.FirstOrDefault().GetChannelAsync(id));
+                if (channel != null) guildId = channel.GuildId;
                 else return null; // we probably don't have the guild in cache if the API doesn't give it to us
             }
             return client.GetGuild(guildId.Value).GetChannel(id);


### PR DESCRIPTION
This changes DiscordShardedClient.GetChannel to get channel.GuildId instead of channel.Id from GetChannelAsync.
Also use `channel` instead of `guild` as the variable name for the channel. Folks, remember to name yall's variables correctly - you never know what bugs you might accidentally introduce if you use a variable name that is misleading! (yes, lol, it was [me](https://github.com/xSke/PluralKit/blame/main/PluralKit.Bot/Utils/DiscordUtils.cs#L274-L275) who wrote this function :stuck_out_tongue:)