### PR TITLE
Fix webp avatar errors

### DIFF
--- a/PluralKit.Bot/Commands/Avatars/ContextAvatarExt.cs
+++ b/PluralKit.Bot/Commands/Avatars/ContextAvatarExt.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -14,8 +14,8 @@ namespace PluralKit.Bot
         // Rewrite cdn.discordapp.com URLs to media.discordapp.net for jpg/png files
         // This lets us add resizing parameters to "borrow" their media proxy server to downsize the image
         // which in turn makes it more likely to be underneath the size limit!
-        private static readonly Regex DiscordCdnUrl = new Regex(@"^https?://(?:cdn\.discordapp\.com|media\.discordapp\.net)/attachments/(\d{17,19})/(\d{17,19})/([^/\\&\?]+)\.(png|jpg|jpeg)(\?.*)?$");
-        private static readonly string DiscordMediaUrlReplacement = "https://media.discordapp.net/attachments/$1/$2/$3.$4?width=256&height=256";
+        private static readonly Regex DiscordCdnUrl = new Regex(@"^https?://(?:cdn\.discordapp\.com|media\.discordapp\.net)/attachments/(\d{17,19})/(\d{17,19})/([^/\\&\?]+)\.(png|jpg|jpeg|webp)(\?.*)?$");
+        private static readonly string DiscordMediaUrlReplacement = "https://media.discordapp.net/attachments/$1/$2/$3.jpg?width=256&height=256";
         
         public static async Task<ParsedImage?> MatchImage(this Context ctx)
         {


### PR DESCRIPTION
Allow uploading images with `.webp` extensions. Also, always use `.jpg` as the requested format from mediaproxy - as the file size will potentially be smaller