### PR TITLE
Tweaks/features

### DIFF
--- a/PluralKit.Bot/Commands/Api.cs
+++ b/PluralKit.Bot/Commands/Api.cs
@@ -7,17 +7,25 @@ using PluralKit.Core;
 
 namespace PluralKit.Bot
 {
-    public class Token
+    public class Api
     {
         private readonly IDatabase _db;
         private readonly ModelRepository _repo;
-        public Token(IDatabase db, ModelRepository repo)
+		private readonly CoreConfig _config;
+
+        public Api(IDatabase db, ModelRepository repo, CoreConfig config)
         {
             _db = db;
             _repo = repo;
+			_config = config;
         }
 
-        public async Task GetToken(Context ctx)
+		public async Task GetUrl(Context ctx) {
+			var GetTokenMessage = ctx.System != null ? "\nUse the **pk;api token** command to get an API authorization token." : "";
+			await ctx.Reply($"The API url for this instance is {_config.ApiUrl}.\nAPI documentation can be found at <https://pluralkit.me/api>.{GetTokenMessage}");
+		}
+
+        public async Task GetToken(Context ctx, bool deprecated = false)
         {
             ctx.CheckSystem();
 
@@ -42,6 +50,8 @@ namespace PluralKit.Bot
                 if (!(ctx.Channel is DiscordDmChannel))
                     await ctx.Reply($"{Emojis.Error} Could not send token in DMs. Are your DMs closed?");
             }
+
+			if (deprecated) await ctx.Reply($"{Emojis.Note} This command is deprecated. Please start using `pk;api token` instead.");
         }
 
         private async Task<string> MakeAndSetNewToken(PKSystem system)
@@ -51,7 +61,7 @@ namespace PluralKit.Bot
             return system.Token;
         }
         
-        public async Task RefreshToken(Context ctx)
+        public async Task RefreshToken(Context ctx, bool deprecated = false)
         {
             ctx.CheckSystem();
             
@@ -83,6 +93,8 @@ namespace PluralKit.Bot
                 if (!(ctx.Channel is DiscordDmChannel))
                     await ctx.Reply($"{Emojis.Error} Could not send token in DMs. Are your DMs closed?");
             }
+
+			if (deprecated) await ctx.Reply($"{Emojis.Note} This command is deprecated. Please start using `pk;api token refresh` instead.");
         }
     }
 }

--- a/PluralKit.Bot/Commands/Autoproxy.cs
+++ b/PluralKit.Bot/Commands/Autoproxy.cs
@@ -53,12 +53,26 @@ namespace PluralKit.Bot
 
         private async Task AutoproxyLatch(Context ctx)
         {
-            if (ctx.MessageContext.AutoproxyMode == AutoproxyMode.Latch)
-                await ctx.Reply($"{Emojis.Note} Autoproxy is already set to latch mode in this server. If you want to disable autoproxying, use `pk;autoproxy off`.");
-            else
+            if (ctx.Match("timeout", "duration"))
             {
-                await UpdateAutoproxy(ctx, AutoproxyMode.Latch, null);
-                await ctx.Reply($"{Emojis.Success} Autoproxy set to latch mode in this server. Messages will now be autoproxied using the *last-proxied member* in this server.");
+                if (!ctx.HasNext())
+                    await ctx.Reply($"The current latch timeout duration for your system is {ctx.System.LatchTimeout} hour(s).");
+                else {
+                    int newTimeout = 6;
+                    if (ctx.Match("off", "stop", "cancel", "no", "disable", "remove")) newTimeout = 0;
+                    else if (!int.TryParse(ctx.RemainderOrNull(), out newTimeout)) throw new PKError("Duration must be an integer.");
+                    await _db.Execute(conn => _repo.UpdateSystem(conn, ctx.System.Id, new SystemPatch{LatchTimeout = newTimeout}));
+                    var resp = (newTimeout != 0) ? $"Latch duration set to {newTimeout} hours." : "Latch timeout disabled.";
+                    await ctx.Reply(resp);
+                }
+            } else {
+                if (ctx.MessageContext.AutoproxyMode == AutoproxyMode.Latch)
+                    await ctx.Reply($"{Emojis.Note} Autoproxy is already set to latch mode in this server. If you want to disable autoproxying, use `pk;autoproxy off`.");
+                else
+                {
+                    await UpdateAutoproxy(ctx, AutoproxyMode.Latch, null);
+                    await ctx.Reply($"{Emojis.Success} Autoproxy set to latch mode in this server. Messages will now be autoproxied using the *last-proxied member* in this server.");
+                }
             }
         }
 

--- a/PluralKit.Bot/Commands/CommandTree.cs
+++ b/PluralKit.Bot/Commands/CommandTree.cs
@@ -42,6 +42,7 @@ namespace PluralKit.Bot
         public static Command MemberServerAvatar = new Command("member serveravatar", "member <member> serveravatar [url|@mention]", "Changes a member's avatar in the current server");
         public static Command MemberDisplayName = new Command("member displayname", "member <member> displayname [display name]", "Changes a member's display name");
         public static Command MemberServerName = new Command("member servername", "member <member> servername [server name]", "Changes a member's display name in the current server");
+        public static Command MemberAutoproxy = new Command("member autoproxy", "member <member> autoproxy [on|off]", "Disables latch/front autoproxy for a member");
         public static Command MemberKeepProxy = new Command("member keepproxy", "member <member> keepproxy [on|off]", "Sets whether to include a member's proxy tags when proxying");
         public static Command MemberRandom = new Command("random", "random", "Looks up a random member from your system");
         public static Command MemberPrivacy = new Command("member privacy", "member <member> privacy <name|description|birthday|pronouns|metadata|visibility|all> <public|private>", "Changes a members's privacy settings");
@@ -351,6 +352,8 @@ namespace PluralKit.Bot
                 await ctx.Execute<MemberEdit>(MemberServerName, m => m.ServerName(ctx, target));
             else if (ctx.Match("keepproxy", "keeptags", "showtags"))
                 await ctx.Execute<MemberEdit>(MemberKeepProxy, m => m.KeepProxy(ctx, target));
+            else if (ctx.Match("autoproxy"))
+                await ctx.Execute<MemberEdit>(MemberAutoproxy, m => m.MemberAutoproxy(ctx, target));
             else if (ctx.Match("privacy"))
                 await ctx.Execute<MemberEdit>(MemberPrivacy, m => m.Privacy(ctx, target, null));
             else if (ctx.Match("private", "hidden", "hide"))

--- a/PluralKit.Bot/Commands/CommandTree.cs
+++ b/PluralKit.Bot/Commands/CommandTree.cs
@@ -28,7 +28,7 @@ namespace PluralKit.Bot
         public static Command SystemFrontPercent = new Command("system frontpercent", "system [system] frontpercent [timespan]", "Shows a system's front breakdown");
         public static Command SystemPing = new Command("system ping", "system ping <enable|disable>", "Changes your system's ping preferences");
         public static Command SystemPrivacy = new Command("system privacy", "system privacy <description|members|fronter|fronthistory|all> <public|private>", "Changes your system's privacy settings");
-        public static Command Autoproxy = new Command("autoproxy", "autoproxy [off|front|latch|member]", "Sets your system's autoproxy mode for this server");
+        public static Command Autoproxy = new Command("autoproxy", "autoproxy [off|front|latch [timeout]|member]", "Sets your system's autoproxy mode for this server");
         public static Command MemberInfo = new Command("member", "member <member>", "Looks up information about a member");
         public static Command MemberNew = new Command("member new", "member new <name>", "Creates a new member");
         public static Command MemberRename = new Command("member rename", "member <member> rename <new name>", "Renames a member");

--- a/PluralKit.Bot/Commands/ImportExport.cs
+++ b/PluralKit.Bot/Commands/ImportExport.cs
@@ -141,11 +141,14 @@ namespace PluralKit.Bot
             try
             {
                 var dm = await ctx.Rest.CreateDmAsync(ctx.Author.Id);
-                await dm.SendFileAsync("system.json", stream, $"{Emojis.Success} Here you go!");
+                var msg = await dm.SendFileAsync("system.json", stream, $"{Emojis.Success} Here you go!");
 
                 // If the original message wasn't posted in DMs, send a public reminder
                 if (!(ctx.Channel is DiscordDmChannel))
                     await ctx.Reply($"{Emojis.Success} Check your DMs!");
+
+                // Send attachment URL, for easier copying on mobile
+                await dm.SendMessageAsync($"<{msg.Attachments[0].Url}>");
             }
             catch (UnauthorizedException)
             {

--- a/PluralKit.Bot/Commands/MemberEdit.cs
+++ b/PluralKit.Bot/Commands/MemberEdit.cs
@@ -373,6 +373,36 @@ namespace PluralKit.Bot
                 await ctx.Reply($"{Emojis.Success} Member proxy tags will now not be included in the resulting message when proxying.");
         }
 
+        public async Task MemberAutoproxy(Context ctx, PKMember target)
+        {
+            if (ctx.System == null) throw Errors.NoSystemError;
+            if (target.System != ctx.System.Id) throw Errors.NotOwnMemberError;
+
+            bool newValue;
+            // having the internal boolvalue be *opposite* to the user-facing bool value is confusing
+            // maybe let's *not* do that at some point
+            if (ctx.Match("on", "enabled", "true", "yes")) newValue = false;
+            else if (ctx.Match("off", "disabled", "false", "no")) newValue = true;
+            else if (ctx.HasNext()) throw new PKSyntaxError("You must pass either \"on\" or \"off\".");
+            else
+            {
+                if (target.DisableAutoproxy)
+                    await ctx.Reply("Latch/front autoproxy are **disabled** for this member. This member will not be automatically proxied when autoproxy is set to latch or front mode.");
+                else
+                    await ctx.Reply("Latch/front autoproxy are **enabled** for this member. This member will be automatically proxied when autoproxy is set to latch or front mode.");
+                return;
+            };
+
+            var patch = new MemberPatch {DisableAutoproxy = Partial<bool>.Present(newValue)};
+            await _db.Execute(conn => _repo.UpdateMember(conn, target.Id, patch));
+            
+            // again, this is confusing
+            if (!newValue)
+                await ctx.Reply($"{Emojis.Success} Latch / front autoproxy have been **enabled** for this member.");
+            else
+                await ctx.Reply($"{Emojis.Success} Latch / front autoproxy have been **disabled** for this member.");
+        }
+
         public async Task Privacy(Context ctx, PKMember target, PrivacyLevel? newValueFromCommand)
         {
             if (ctx.System == null) throw Errors.NoSystemError;

--- a/PluralKit.Bot/Modules.cs
+++ b/PluralKit.Bot/Modules.cs
@@ -31,6 +31,7 @@ namespace PluralKit.Bot
 
             // Commands
             builder.RegisterType<CommandTree>().AsSelf();
+            builder.RegisterType<Api>().AsSelf();
             builder.RegisterType<Autoproxy>().AsSelf();
             builder.RegisterType<Fun>().AsSelf();
             builder.RegisterType<Groups>().AsSelf();
@@ -48,7 +49,6 @@ namespace PluralKit.Bot
             builder.RegisterType<SystemFront>().AsSelf();
             builder.RegisterType<SystemLink>().AsSelf();
             builder.RegisterType<SystemList>().AsSelf();
-            builder.RegisterType<Token>().AsSelf();
             
             // Bot core
             builder.RegisterType<Bot>().AsSelf().SingleInstance();

--- a/PluralKit.Bot/Proxy/ProxyMatcher.cs
+++ b/PluralKit.Bot/Proxy/ProxyMatcher.cs
@@ -55,13 +55,13 @@ namespace PluralKit.Bot
                 AutoproxyMode.Front when ctx.LastSwitchMembers.Length > 0 => 
                     members.FirstOrDefault(m => m.Id == ctx.LastSwitchMembers[0]),
                 
-                AutoproxyMode.Latch when ctx.LastMessageMember != null && !IsLatchExpired(ctx.LastMessage) =>
+                AutoproxyMode.Latch when ctx.LastMessageMember != null && !IsLatchExpired(ctx) =>
                     members.FirstOrDefault(m => m.Id == ctx.LastMessageMember.Value),
                 
                 _ => null
             };
 
-            if (member == null) return false;
+            if (member == null || (ctx.AutoproxyMode != AutoproxyMode.Member && member.DisableAutoproxy)) return false;
             match = new ProxyMatch
             {
                 Content = messageContent,

--- a/PluralKit.Bot/Proxy/ProxyMatcher.cs
+++ b/PluralKit.Bot/Proxy/ProxyMatcher.cs
@@ -77,6 +77,7 @@ namespace PluralKit.Bot
         private bool IsLatchExpired(MessageContext ctx)
         {
             if (ctx.LastMessage == null) return true;
+            if (ctx.LatchTimeout == 0) return false;
             var timestamp = DiscordUtils.SnowflakeToInstant(ctx.LastMessage.Value);
             return _clock.GetCurrentInstant() - timestamp > Duration.FromHours(ctx.LatchTimeout);
         }

--- a/PluralKit.Bot/Proxy/ProxyMatcher.cs
+++ b/PluralKit.Bot/Proxy/ProxyMatcher.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 
 using NodaTime;
@@ -10,7 +10,6 @@ namespace PluralKit.Bot
     public class ProxyMatcher
     {
         private static readonly char AutoproxyEscapeCharacter = '\\';
-        private static readonly Duration LatchExpiryTime = Duration.FromHours(6);
 
         private readonly IClock _clock;
         private readonly ProxyTagParser _parser;
@@ -75,11 +74,11 @@ namespace PluralKit.Bot
             return true;
         }
 
-        private bool IsLatchExpired(ulong? messageId)
+        private bool IsLatchExpired(MessageContext ctx)
         {
-            if (messageId == null) return true;
-            var timestamp = DiscordUtils.SnowflakeToInstant(messageId.Value);
-            return _clock.GetCurrentInstant() - timestamp > LatchExpiryTime;
+            if (ctx.LastMessage == null) return true;
+            var timestamp = DiscordUtils.SnowflakeToInstant(ctx.LastMessage.Value);
+            return _clock.GetCurrentInstant() - timestamp > Duration.FromHours(ctx.LatchTimeout);
         }
     }
 }

--- a/PluralKit.Core/CoreConfig.cs
+++ b/PluralKit.Core/CoreConfig.cs
@@ -10,6 +10,7 @@ namespace PluralKit.Core
         public string InfluxDb { get; set; }
         public string LogDir { get; set; }
         public string ElasticUrl { get; set; }
+        public string ApiUrl { get; set; } = "";
 
         public LogEventLevel ConsoleLogLevel { get; set; } = LogEventLevel.Debug;
         public LogEventLevel FileLogLevel { get; set; } = LogEventLevel.Information;

--- a/PluralKit.Core/Database/Database.cs
+++ b/PluralKit.Core/Database/Database.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.IO;
@@ -19,7 +19,7 @@ namespace PluralKit.Core
     internal class Database: IDatabase
     {
         private const string RootPath = "PluralKit.Core.Database"; // "resource path" root for SQL files
-        private const int TargetSchemaVersion = 9;
+        private const int TargetSchemaVersion = 10;
         
         private readonly CoreConfig _config;
         private readonly ILogger _logger;

--- a/PluralKit.Core/Database/Functions/MessageContext.cs
+++ b/PluralKit.Core/Database/Functions/MessageContext.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using NodaTime;
 
@@ -24,5 +24,6 @@ namespace PluralKit.Core
         public Instant? LastSwitchTimestamp { get; }
         public string? SystemTag { get; }
         public string? SystemAvatar { get; }
+        public int LatchTimeout { get; }
     }
 }

--- a/PluralKit.Core/Database/Functions/ProxyMember.cs
+++ b/PluralKit.Core/Database/Functions/ProxyMember.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System.Collections.Generic;
 
 namespace PluralKit.Core
@@ -18,6 +18,8 @@ namespace PluralKit.Core
         
         public string? ServerAvatar { get; }
         public string? Avatar { get; }
+
+        public bool DisableAutoproxy { get; }
 
         public string ProxyName(MessageContext ctx) => ctx.SystemTag != null
             ? $"{ServerName ?? DisplayName ?? Name} {ctx.SystemTag}"

--- a/PluralKit.Core/Database/Functions/functions.sql
+++ b/PluralKit.Core/Database/Functions/functions.sql
@@ -1,4 +1,4 @@
-﻿create function message_context(account_id bigint, guild_id bigint, channel_id bigint)
+create function message_context(account_id bigint, guild_id bigint, channel_id bigint)
     returns table (
         system_id int,
         log_channel bigint,
@@ -14,7 +14,8 @@
         last_switch_members int[],
         last_switch_timestamp timestamp,
         system_tag text,
-        system_avatar text
+        system_avatar text,
+        latch_timeout integer
     )
 as $$
     -- CTEs to query "static" (accessible only through args) data
@@ -37,7 +38,8 @@ as $$
         system_last_switch.members as last_switch_members,
         system_last_switch.timestamp as last_switch_timestamp,
         system.tag as system_tag,
-        system.avatar_url as system_avatar
+        system.avatar_url as system_avatar,
+        system.latch_timeout as latch_timeout
     -- We need a "from" clause, so we just use some bogus data that's always present
     -- This ensure we always have exactly one row going forward, so we can left join afterwards and still get data
     from (select 1) as _placeholder

--- a/PluralKit.Core/Database/Functions/functions.sql
+++ b/PluralKit.Core/Database/Functions/functions.sql
@@ -64,7 +64,9 @@ create function proxy_members(account_id bigint, guild_id bigint)
         name text,
         
         server_avatar text,
-        avatar text
+        avatar text,
+
+        disable_autoproxy bool
     )
 as $$
     select
@@ -80,7 +82,9 @@ as $$
         
         -- Avatar info
         member_guild.avatar_url as server_avatar,
-        members.avatar_url as avatar
+        members.avatar_url as avatar,
+
+        members.disable_autoproxy as disable_autoproxy
     from accounts
         inner join systems on systems.id = accounts.system
         inner join members on members.system = systems.id

--- a/PluralKit.Core/Database/Migrations/10.sql
+++ b/PluralKit.Core/Database/Migrations/10.sql
@@ -1,0 +1,6 @@
+-- SCHEMA VERSION 10: <insert date> --
+-- Add disabling front/latch autoproxy per-member; add custom latch timeout per-system --
+
+alter table members add column disable_autoproxy bool not null default false;
+alter table systems add column latch_timeout int not null default 6;
+update info set schema_version = 10;

--- a/PluralKit.Core/Models/PKMember.cs
+++ b/PluralKit.Core/Models/PKMember.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 using Newtonsoft.Json;
 
@@ -24,6 +24,7 @@ namespace PluralKit.Core {
         public bool KeepProxy { get; private set; }
         public Instant Created { get; private set; }
         public int MessageCount { get; private set; }
+        public bool DisableAutoproxy { get; private set; }
 
         public PrivacyLevel MemberVisibility { get; private set; }
         public PrivacyLevel DescriptionPrivacy { get; private set; }

--- a/PluralKit.Core/Models/PKSystem.cs
+++ b/PluralKit.Core/Models/PKSystem.cs
@@ -1,4 +1,4 @@
-﻿using Dapper.Contrib.Extensions;
+using Dapper.Contrib.Extensions;
 
 using Newtonsoft.Json;
 
@@ -18,6 +18,7 @@ namespace PluralKit.Core {
         public Instant Created { get; }
         public string UiTz { get; set; }
         public bool PingsEnabled { get; }
+        public int LatchTimeout { get; }
 	    public PrivacyLevel DescriptionPrivacy { get; }
         public PrivacyLevel MemberListPrivacy { get;}
         public PrivacyLevel FrontPrivacy { get; }

--- a/PluralKit.Core/Models/Patch/MemberPatch.cs
+++ b/PluralKit.Core/Models/Patch/MemberPatch.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using NodaTime;
 
@@ -16,6 +16,7 @@ namespace PluralKit.Core
         public Partial<ProxyTag[]> ProxyTags { get; set; }
         public Partial<bool> KeepProxy { get; set; }
         public Partial<int> MessageCount { get; set; }
+        public Partial<bool> DisableAutoproxy { get; set; }
         public Partial<PrivacyLevel> Visibility { get; set; }
         public Partial<PrivacyLevel> NamePrivacy { get; set; }
         public Partial<PrivacyLevel> DescriptionPrivacy { get; set; }
@@ -35,6 +36,7 @@ namespace PluralKit.Core
             .With("proxy_tags", ProxyTags)
             .With("keep_proxy", KeepProxy)
             .With("message_count", MessageCount)
+            .With("disable_autoproxy", DisableAutoproxy)
             .With("member_visibility", Visibility)
             .With("name_privacy", NamePrivacy)
             .With("description_privacy", DescriptionPrivacy)

--- a/PluralKit.Core/Models/Patch/SystemPatch.cs
+++ b/PluralKit.Core/Models/Patch/SystemPatch.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 namespace PluralKit.Core
 {
     public class SystemPatch: PatchObject
@@ -9,6 +9,7 @@ namespace PluralKit.Core
         public Partial<string?> AvatarUrl { get; set; }
         public Partial<string?> Token { get; set; }
         public Partial<string> UiTz { get; set; }
+        public Partial<int> LatchTimeout { get; set; }
         public Partial<PrivacyLevel> DescriptionPrivacy { get; set; }
         public Partial<PrivacyLevel> MemberListPrivacy { get; set; }
         public Partial<PrivacyLevel> GroupListPrivacy { get; set; }
@@ -23,6 +24,7 @@ namespace PluralKit.Core
             .With("avatar_url", AvatarUrl)
             .With("token", Token)
             .With("ui_tz", UiTz)
+            .With("latch_timeout", LatchTimeout)
             .With("description_privacy", DescriptionPrivacy)
             .With("member_list_privacy", MemberListPrivacy)
             .With("group_list_privacy", GroupListPrivacy)


### PR DESCRIPTION
* feature: `pk;api` command group - can be useful for adding more API-specific commands if any are ever needed
* tweak: send attachment URL after sending export file
* feature: configurable latch timeout duration (value of `0` disables timeout altogether)
* feature: disable front/latch autoproxy per-member (disabling member-specific autoproxy feels kinda pointless as one can just, not set autoproxy to that member)