### PR TITLE
Allow deleting bot responses with :x: reaction

### DIFF
--- a/PluralKit.Bot/Bot.cs
+++ b/PluralKit.Bot/Bot.cs
@@ -9,6 +9,8 @@ using App.Metrics;
 
 using Autofac;
 
+using Dapper;
+
 using DSharpPlus;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
@@ -34,18 +36,21 @@ namespace PluralKit.Bot
         private readonly PeriodicStatCollector _collector;
         private readonly IMetrics _metrics;
         private readonly ErrorMessageService _errorMessageService;
+        private readonly IDatabase _db;
 
         private bool _hasReceivedReady = false;
         private Timer _periodicTask; // Never read, just kept here for GC reasons
 
-        public Bot(DiscordShardedClient client, ILifetimeScope services, ILogger logger, PeriodicStatCollector collector, IMetrics metrics, ErrorMessageService errorMessageService)
+        public Bot(DiscordShardedClient client, ILifetimeScope services, ILogger logger, PeriodicStatCollector collector, IMetrics metrics, 
+            ErrorMessageService errorMessageService, IDatabase db)
         {
             _client = client;
+            _logger = logger.ForContext<Bot>();
             _services = services;
             _collector = collector;
             _metrics = metrics;
             _errorMessageService = errorMessageService;
-            _logger = logger.ForContext<Bot>();
+            _db = db;
         }
 
         public void Init()
@@ -176,6 +181,9 @@ namespace PluralKit.Bot
             _logger.Debug("Running once-per-minute scheduled tasks");
 
             await UpdateBotStatus();
+
+            // Clean up message cache in postgres
+            await _db.Execute(conn => conn.QueryAsync("select from cleanup_command_message()"));
 
             // Collect some stats, submit them to the metrics backend
             await _collector.CollectStats();

--- a/PluralKit.Bot/CommandSystem/Context.cs
+++ b/PluralKit.Bot/CommandSystem/Context.cs
@@ -64,7 +64,7 @@ namespace PluralKit.Bot
         internal IDatabase Database => _db;
         internal ModelRepository Repository => _repo;
 
-        public Task<DiscordMessage> Reply(string text = null, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
+        public async Task<DiscordMessage> Reply(string text = null, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
         {
             if (!this.BotHasAllPermissions(Permissions.SendMessages))
                 // Will be "swallowed" during the error handler anyway, this message is never shown.
@@ -72,7 +72,12 @@ namespace PluralKit.Bot
 
             if (embed != null && !this.BotHasAllPermissions(Permissions.EmbedLinks))
                 throw new PKError("PluralKit does not have permission to send embeds in this channel. Please ensure I have the **Embed Links** permission enabled.");
-            return Channel.SendMessageFixedAsync(text, embed: embed, mentions: mentions);
+            var msg = await Channel.SendMessageFixedAsync(text, embed: embed, mentions: mentions);
+            if (embed != null) 
+                // Sensitive information that might want to be deleted by :x: reaction is typically in an embed format (member cards, for example)
+                // This may need to be changed at some point but works well enough for now
+                await _db.Execute(conn => _repo.SaveCommandMessage(conn, msg.Id, Author.Id));
+            return msg;
         }
         
         public async Task Execute<T>(Command commandDef, Func<T, Task> handler)

--- a/PluralKit.Bot/Commands/CommandTree.cs
+++ b/PluralKit.Bot/Commands/CommandTree.cs
@@ -189,9 +189,9 @@ namespace PluralKit.Bot
             if (ctx.Match("random", "r"))
                 return ctx.Execute<Member>(MemberRandom, m => m.MemberRandom(ctx));
 
-            ctx.Reply(
+            // remove compiler warning
+            return ctx.Reply(
                 $"{Emojis.Error} Unknown command {ctx.PeekArgument().AsCode()}. For a list of possible commands, see <https://pluralkit.me/commands>.");
-            return Task.CompletedTask;
         }
 
         private async Task HandleSystemCommand(Context ctx)

--- a/PluralKit.Core/Database/Database.cs
+++ b/PluralKit.Core/Database/Database.cs
@@ -19,7 +19,7 @@ namespace PluralKit.Core
     internal class Database: IDatabase
     {
         private const string RootPath = "PluralKit.Core.Database"; // "resource path" root for SQL files
-        private const int TargetSchemaVersion = 10;
+        private const int TargetSchemaVersion = 11;
         
         private readonly CoreConfig _config;
         private readonly ILogger _logger;

--- a/PluralKit.Core/Database/Migrations/11.sql
+++ b/PluralKit.Core/Database/Migrations/11.sql
@@ -4,7 +4,7 @@
 create table command_message
 (
 	message_id bigint primary key,
-	invoker_id bigint not null,
+	author_id bigint not null,
 	timestamp timestamp not null default now()
 );
 

--- a/PluralKit.Core/Database/Migrations/11.sql
+++ b/PluralKit.Core/Database/Migrations/11.sql
@@ -1,0 +1,17 @@
+-- SCHEMA VERSION 11: (insert date) --
+-- Create command message table --
+
+create table command_message
+(
+	message_id bigint primary key,
+	invoker_id bigint not null,
+	timestamp timestamp not null default now()
+);
+
+create function cleanup_command_message() returns void as $$
+begin
+    delete from command_message where timestamp < now() - interval '1 minute';
+end;
+$$ language plpgsql;
+
+update info set schema_version = 11;

--- a/PluralKit.Core/Database/Migrations/11.sql
+++ b/PluralKit.Core/Database/Migrations/11.sql
@@ -10,7 +10,7 @@ create table command_message
 
 create function cleanup_command_message() returns void as $$
 begin
-    delete from command_message where timestamp < now() - interval '1 minute';
+    delete from command_message where timestamp < now() - interval '1 hour';
 end;
 $$ language plpgsql;
 

--- a/PluralKit.Core/Database/Migrations/11.sql
+++ b/PluralKit.Core/Database/Migrations/11.sql
@@ -10,7 +10,7 @@ create table command_message
 
 create function cleanup_command_message() returns void as $$
 begin
-    delete from command_message where timestamp < now() - interval '1 hour';
+    delete from command_message where timestamp < now() - interval '2 hours';
 end;
 $$ language plpgsql;
 

--- a/PluralKit.Core/Database/Repository/ModelRepository.CommandMessage.cs
+++ b/PluralKit.Core/Database/Repository/ModelRepository.CommandMessage.cs
@@ -9,7 +9,16 @@ namespace PluralKit.Core
     public partial class ModelRepository
 	{
 		public Task SaveCommandMessage(IPKConnection conn, ulong message_id, ulong author_id) =>
-			conn.QueryAsync("insert into command_message (message_id, invoker_id) values (@Message, @Author)",
+			conn.QueryAsync("insert into command_message (message_id, author_id) values (@Message, @Author)",
 				new {Message = message_id, Author = author_id });
+
+		public Task<CommandMessage> GetCommandMessage(IPKConnection conn, ulong message_id) =>
+			conn.QuerySingleOrDefaultAsync<CommandMessage>("select message_id, author_id from command_message where message_id = @Message", 
+				new {Message = message_id});
+	}
+
+	public class CommandMessage
+	{
+		public ulong author_id { get; set; }
 	}
 }

--- a/PluralKit.Core/Database/Repository/ModelRepository.CommandMessage.cs
+++ b/PluralKit.Core/Database/Repository/ModelRepository.CommandMessage.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Threading.Tasks;
+
+using Dapper;
+
+namespace PluralKit.Core
+{
+    public partial class ModelRepository
+	{
+		public Task SaveCommandMessage(IPKConnection conn, ulong message_id, ulong author_id) =>
+			conn.QueryAsync("insert into command_message (message_id, invoker_id) values (@Message, @Author)",
+				new {Message = message_id, Author = author_id });
+	}
+}


### PR DESCRIPTION
Closes #170.

I chose to put this in the database instead of a bot cache because it would be unfortunate if someone posted some information they then wanted to delete, and the bot was restarted right after.

Currently, only messages that contain an embed are able to be deleted by reaction.
The timeout is 1 hour, and old rows get cleaned up by the once-a-minute scheduled task.