### PR TITLE
Add "member is public" reminder message on member creation

### DIFF
--- a/PluralKit.Bot/Commands/Member.cs
+++ b/PluralKit.Bot/Commands/Member.cs
@@ -2,6 +2,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 
+using Dapper;
+
 using PluralKit.Core;
 
 namespace PluralKit.Bot
@@ -47,6 +49,9 @@ namespace PluralKit.Bot
             
             // Send confirmation and space hint
             await ctx.Reply($"{Emojis.Success} Member \"{memberName}\" (`{member.Hid}`) registered! Check out the getting started page for how to get a member up and running: https://pluralkit.me/start#members");
+            if (await _db.Execute(conn => conn.QuerySingleAsync<bool>("select has_private_members(@System)",
+                new {System = ctx.System.Id}))) //if has private members
+                await ctx.Reply($"{Emojis.Warn} This member is currently **public**. To change this, use the `pk;member {member.Hid} privacy` command.");
             if (memberName.Contains(" "))
                 await ctx.Reply($"{Emojis.Note} Note that this member's name contains spaces. You will need to surround it with \"double quotes\" when using commands referring to it, or just use the member's 5-character ID (which is `{member.Hid}`).");
             if (memberCount >= Limits.MaxMemberCount)

--- a/PluralKit.Bot/Commands/Member.cs
+++ b/PluralKit.Bot/Commands/Member.cs
@@ -51,7 +51,7 @@ namespace PluralKit.Bot
             await ctx.Reply($"{Emojis.Success} Member \"{memberName}\" (`{member.Hid}`) registered! Check out the getting started page for how to get a member up and running: https://pluralkit.me/start#members");
             if (await _db.Execute(conn => conn.QuerySingleAsync<bool>("select has_private_members(@System)",
                 new {System = ctx.System.Id}))) //if has private members
-                await ctx.Reply($"{Emojis.Warn} This member is currently **public**. To change this, use the `pk;member {member.Hid} privacy` command.");
+                await ctx.Reply($"{Emojis.Warn} This member is currently **public**. To change this, use `pk;member {member.Hid} private`.");
             if (memberName.Contains(" "))
                 await ctx.Reply($"{Emojis.Note} Note that this member's name contains spaces. You will need to surround it with \"double quotes\" when using commands referring to it, or just use the member's 5-character ID (which is `{member.Hid}`).");
             if (memberCount >= Limits.MaxMemberCount)

--- a/PluralKit.Core/Database/Functions/functions.sql
+++ b/PluralKit.Core/Database/Functions/functions.sql
@@ -86,6 +86,15 @@ as $$
     where accounts.uid = account_id
 $$ language sql stable rows 10;
 
+create function has_private_members(system_hid int) returns bool as $$
+declare m int;
+begin
+    m := count(id) from members where system = system_hid and member_visibility = 2;
+    if m > 0 then return true;
+    else return false;
+    end if;
+end
+$$ language plpgsql;
 
 create function generate_hid() returns char(5) as $$
     select string_agg(substr('abcdefghijklmnopqrstuvwxyz', ceil(random() * 26)::integer, 1), '') from generate_series(1, 5)

--- a/PluralKit.Core/Database/clean.sql
+++ b/PluralKit.Core/Database/clean.sql
@@ -9,6 +9,7 @@ drop view if exists group_list;
 
 drop function if exists message_context;
 drop function if exists proxy_members;
+drop function if exists has_private_members;
 drop function if exists generate_hid;
 drop function if exists find_free_system_hid;
 drop function if exists find_free_member_hid;


### PR DESCRIPTION
(if system has any private members - that is, any members with visibility set to private)