### PR TITLE
Add time switch was moved to to success message

### DIFF
--- a/PluralKit.Bot/Commands/Switch.cs
+++ b/PluralKit.Bot/Commands/Switch.cs
@@ -105,7 +105,7 @@ namespace PluralKit.Bot
             
             // aaaand *now* we do the move
             await _repo.MoveSwitch(conn, lastTwoSwitches[0].Id, time.ToInstant());
-            await ctx.Reply($"{Emojis.Success} Switch moved.");
+            await ctx.Reply($"{Emojis.Success} Switch moved to {newSwitchTimeStr} ({newSwitchDeltaStr} ago).");
         }
         
         public async Task SwitchDelete(Context ctx)


### PR DESCRIPTION
Incredibly minor change (the change is literally copied from the same file, 5 lines above), but useful when using the `-y` flag to move switches without having to confirm the move.