### PR TITLE
Add proxy debug command

### DIFF
--- a/PluralKit.Bot/Commands/CommandTree.cs
+++ b/PluralKit.Bot/Commands/CommandTree.cs
@@ -191,7 +191,10 @@ namespace PluralKit.Bot
                     return PrintCommandList(ctx, "channel blacklisting", BlacklistCommands);
                 else return PrintCommandExpectedError(ctx, BlacklistCommands);
             if (ctx.Match("proxy", "enable", "disable"))
-                return ctx.Execute<SystemEdit>(SystemProxy, m => m.SystemProxy(ctx));
+                if (ctx.Match("debug"))
+                    return ctx.Execute<Misc>(null, m => m.DebugProxy(ctx));
+                else
+                    return ctx.Execute<SystemEdit>(SystemProxy, m => m.SystemProxy(ctx));
             if (ctx.Match("invite")) return ctx.Execute<Misc>(Invite, m => m.Invite(ctx));
             if (ctx.Match("mn")) return ctx.Execute<Fun>(null, m => m.Mn(ctx));
             if (ctx.Match("fire")) return ctx.Execute<Fun>(null, m => m.Fire(ctx));

--- a/PluralKit.Bot/Commands/Misc.cs
+++ b/PluralKit.Bot/Commands/Misc.cs
@@ -25,8 +25,9 @@ namespace PluralKit.Bot {
         private readonly EmbedService _embeds;
         private readonly IDatabase _db;
         private readonly ModelRepository _repo;
+        private readonly ProxyService _proxy;
 
-        public Misc(BotConfig botConfig, IMetrics metrics, CpuStatService cpu, ShardInfoService shards, EmbedService embeds, ModelRepository repo, IDatabase db)
+        public Misc(BotConfig botConfig, IMetrics metrics, CpuStatService cpu, ShardInfoService shards, EmbedService embeds, ModelRepository repo, IDatabase db, ProxyService proxy)
         {
             _botConfig = botConfig;
             _metrics = metrics;
@@ -35,6 +36,7 @@ namespace PluralKit.Bot {
             _embeds = embeds;
             _repo = repo;
             _db = db;
+            _proxy = proxy;
         }
         
         public async Task Invite(Context ctx)
@@ -189,7 +191,21 @@ namespace PluralKit.Bot {
             // Send! :)
             await ctx.Reply(embed: eb.Build());
         }
-        
+
+        public async Task DebugProxy(Context ctx)
+        {
+            try
+            {
+                await _proxy.HandleIncomingMessage(ctx.Shard, ctx.Message, ctx.MessageContext, allowAutoproxy: true, isCheckingProxy: true);
+            }
+            catch (ProxyRejection e)
+            {
+                await ctx.Reply($"{Emojis.Error} Error found: `{e.Message}`");
+                return;
+            }
+            await ctx.Reply($"{Emojis.Success} No issues found!");
+        }
+
         public async Task GetMessage(Context ctx)
         {
             var word = ctx.PopArgument() ?? throw new PKSyntaxError("You must pass a message ID or link.");

--- a/PluralKit.Bot/Handlers/MessageCreated.cs
+++ b/PluralKit.Bot/Handlers/MessageCreated.cs
@@ -141,6 +141,9 @@ namespace PluralKit.Bot
             }
             catch (PKError e)
             {
+                // ProxyRejection errors are used for proxy debugging, so ignoring them here
+                if (e is ProxyRejection) return false;
+
                 // User-facing errors, print to the channel properly formatted
                 var msg = evt.Message;
                 if (msg.Channel.Guild == null || msg.Channel.BotHasAllPermissions(Permissions.SendMessages))


### PR DESCRIPTION
A note: the message with the `pk;proxy debug` command does need to be a message that would be otherwise proxied; so it needs to include suffix proxy tags or for the author to have `pk;` as a proxy tag. 
Would it be possible to create a system with an example member with `pk;` proxy tag, and give that system ID to `GetProxyMembers` when debugging?