### PR TITLE
Add display options to short member list

### DIFF
--- a/PluralKit.Bot/Commands/Lists/ContextListExt.cs
+++ b/PluralKit.Bot/Commands/Lists/ContextListExt.cs
@@ -184,16 +184,16 @@ namespace PluralKit.Bot
                     if (m.ProxyTags.Count > 0) 
                         profile.Append($"\n**Proxy tags**: {m.ProxyTagsString()}");
                     
-                    if (opts.IncludeMessageCount && m.MessageCountFor(lookupCtx) is {} count && count > 0)
+                    if ((opts.IncludeMessageCount || opts.SortProperty == SortProperty.MessageCount) && m.MessageCountFor(lookupCtx) is {} count && count > 0)
                         profile.Append($"\n**Message count:** {count}");
                     
-                    if (opts.IncludeLastMessage && m.MetadataPrivacy.TryGet(lookupCtx, m.LastMessage, out var lastMsg)) 
+                    if ((opts.IncludeLastMessage || opts.SortProperty == SortProperty.LastMessage) && m.MetadataPrivacy.TryGet(lookupCtx, m.LastMessage, out var lastMsg)) 
                         profile.Append($"\n**Last message:** {DiscordUtils.SnowflakeToInstant(lastMsg.Value).FormatZoned(zone)}");
                     
-                    if (opts.IncludeLastSwitch && m.MetadataPrivacy.TryGet(lookupCtx, m.LastSwitchTime, out var lastSw)) 
+                    if ((opts.IncludeLastSwitch || opts.SortProperty == SortProperty.LastSwitch) && m.MetadataPrivacy.TryGet(lookupCtx, m.LastSwitchTime, out var lastSw)) 
                         profile.Append($"\n**Last switched in:** {lastSw.Value.FormatZoned(zone)}");
 
-                    if (opts.IncludeCreated && m.MetadataPrivacy.TryGet(lookupCtx, m.Created, out var created))
+                    if ((opts.IncludeCreated || opts.SortProperty == SortProperty.CreationDate) && m.MetadataPrivacy.TryGet(lookupCtx, m.Created, out var created))
                         profile.Append($"\n**Created on:** {created.FormatZoned(zone)}");
                     
                     if (opts.IncludeAvatar && m.AvatarFor(lookupCtx) is {} avatar)

--- a/PluralKit.Bot/Commands/Lists/MemberListOptions.cs
+++ b/PluralKit.Bot/Commands/Lists/MemberListOptions.cs
@@ -26,6 +26,7 @@ namespace PluralKit.Bot
         public bool IncludeLastMessage { get; set; }
         public bool IncludeCreated { get; set; }
         public bool IncludeAvatar { get; set; }
+        public bool IncludePronouns { get; set; }
         
         public string CreateFilterString()
         {
@@ -46,6 +47,11 @@ namespace PluralKit.Bot
                 _ => new ArgumentOutOfRangeException($"Couldn't find readable string for sort property {SortProperty}")
             });
             
+            // only works if you're not sorting by something else that would be displayed instead
+            // TODO: does this need to change for full list?
+            if (IncludePronouns && (SortProperty == SortProperty.Name || SortProperty == SortProperty.DisplayName || SortProperty == SortProperty.Random))
+                str.Append(", including pronouns");
+
             if (Search != null)
             {
                 str.Append($", searching for \"{Search}\"");


### PR DESCRIPTION
This PR adds showing the following to the short member list as properties 
- Birthday
- Message count
- Last front
- Creation date
- Pronouns (only shown, not sorted), via a new `with-pronouns` flag
- Last proxy timestamp

This also adapts the full list to show the sort property's relevant item without needing to use *both* the sort and show flag.