### PR TITLE
Add group front percentages

### DIFF
--- a/PluralKit.Bot/Commands/CommandTree.cs
+++ b/PluralKit.Bot/Commands/CommandTree.cs
@@ -60,6 +60,7 @@ namespace PluralKit.Bot
         public static Command GroupPrivacy = new Command("group privacy", "group <group> privacy <description|icon|visibility|all> <public|private>", "Changes a group's privacy settings");
         public static Command GroupIcon = new Command("group icon", "group <group> icon [url|@mention]", "Changes a group's icon");
         public static Command GroupDelete = new Command("group delete", "group <group> delete", "Deletes a group");
+        public static Command GroupFrontPercent = new Command("group frontpercent", "group <group> frontpercent [timespan]", "Shows a group's front breakdown.");
         public static Command GroupMemberRandom = new Command("group random", "group <group> random", "Shows the info card of a randomly selected member in a group.");
         public static Command GroupRandom = new Command("random", "random group", "Shows the info card of a randomly selected group in your system.");
         public static Command Switch = new Command("switch", "switch <member> [member 2] [member 3...]", "Registers a switch");
@@ -107,7 +108,7 @@ namespace PluralKit.Bot
         public static Command[] GroupCommandsTargeted =
         {
             GroupInfo, GroupAdd, GroupRemove, GroupMemberList, GroupRename, GroupDesc, GroupIcon, GroupPrivacy,
-            GroupDelete, GroupMemberRandom
+            GroupDelete, GroupMemberRandom, GroupFrontPercent
         };
 
         public static Command[] SwitchCommands = {Switch, SwitchOut, SwitchMove, SwitchDelete, SwitchDeleteAll};
@@ -397,6 +398,8 @@ namespace PluralKit.Bot
                     await ctx.Execute<Groups>(GroupDelete, g => g.DeleteGroup(ctx, target));
                 else if (ctx.Match("avatar", "picture", "icon", "image", "pic", "pfp"))
                     await ctx.Execute<Groups>(GroupIcon, g => g.GroupIcon(ctx, target));
+                else if (ctx.Match("fp", "frontpercent", "front%", "frontbreakdown"))
+                    await ctx.Execute<Groups>(GroupFrontPercent, g => g.GroupFrontPercent(ctx, target));
                 else if (!ctx.HasNext())
                     await ctx.Execute<Groups>(GroupInfo, g => g.ShowGroupCard(ctx, target));
                 else

--- a/PluralKit.Bot/Commands/Groups.cs
+++ b/PluralKit.Bot/Commands/Groups.cs
@@ -8,6 +8,8 @@ using Dapper;
 
 using Humanizer;
 
+using NodaTime;
+
 using Myriad.Builders;
 
 using PluralKit.Core;
@@ -426,6 +428,31 @@ namespace PluralKit.Bot
             await _db.Execute(conn => _repo.DeleteGroup(conn, target.Id));
             
             await ctx.Reply($"{Emojis.Success} Group deleted.");
+        }
+
+            public async Task GroupFrontPercent(Context ctx, PKGroup target)
+        {
+            await using var conn = await _db.Obtain();
+            
+            var targetSystem = await GetGroupSystem(ctx, target, conn);
+            ctx.CheckSystemPrivacy(targetSystem, targetSystem.FrontHistoryPrivacy);
+
+            string durationStr = ctx.RemainderOrNull() ?? "30d";
+            
+            var now = SystemClock.Instance.GetCurrentInstant();
+
+            var rangeStart = DateUtils.ParseDateTime(durationStr, true, targetSystem.Zone);
+            if (rangeStart == null) throw Errors.InvalidDateTime(durationStr);
+            if (rangeStart.Value.ToInstant() > now) throw Errors.FrontPercentTimeInFuture;
+
+            var title = new StringBuilder($"Frontpercent of {target.DisplayName ?? target.Name} (`{target.Hid}`) in ");
+            if (targetSystem.Name != null) 
+                title.Append($"{targetSystem.Name} (`{targetSystem.Hid}`)");
+            else
+                title.Append($"`{targetSystem.Hid}`");
+
+            var frontpercent = await _db.Execute(c => _repo.GetFrontBreakdown(c, targetSystem.Id, target.Id, rangeStart.Value.ToInstant(), now));
+            await ctx.Reply(embed: await _embeds.CreateFrontPercentEmbed(frontpercent, targetSystem, target, targetSystem.Zone, ctx.LookupContextFor(targetSystem), title.ToString()));
         }
 
         private async Task<PKSystem> GetGroupSystem(Context ctx, PKGroup target, IPKConnection conn)

--- a/PluralKit.Bot/Commands/SystemFront.cs
+++ b/PluralKit.Bot/Commands/SystemFront.cs
@@ -124,8 +124,14 @@ namespace PluralKit.Bot
             if (rangeStart == null) throw Errors.InvalidDateTime(durationStr);
             if (rangeStart.Value.ToInstant() > now) throw Errors.FrontPercentTimeInFuture;
 
-            var frontpercent = await _db.Execute(c => _repo.GetFrontBreakdown(c, system.Id, rangeStart.Value.ToInstant(), now));
-            await ctx.Reply(embed: await _embeds.CreateFrontPercentEmbed(frontpercent, system.Zone, ctx.LookupContextFor(system)));
+            var title = new StringBuilder($"Frontpercent of ");
+            if (system.Name != null) 
+                title.Append($"{system.Name} (`{system.Hid}`)");
+            else
+                title.Append($"`{system.Hid}`");
+
+            var frontpercent = await _db.Execute(c => _repo.GetFrontBreakdown(c, system.Id, null, rangeStart.Value.ToInstant(), now));
+            await ctx.Reply(embed: await _embeds.CreateFrontPercentEmbed(frontpercent, system, null, system.Zone, ctx.LookupContextFor(system), title.ToString()));
         }
     }
 }

--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -293,12 +293,13 @@ namespace PluralKit.Bot {
             return eb.Build();
         }
 
-        public Task<Embed> CreateFrontPercentEmbed(FrontBreakdown breakdown, DateTimeZone tz, LookupContext ctx)
+        public Task<Embed> CreateFrontPercentEmbed(FrontBreakdown breakdown, PKSystem system, PKGroup group, DateTimeZone tz, LookupContext ctx, string embedTitle)
         {
             var actualPeriod = breakdown.RangeEnd - breakdown.RangeStart;
             var eb = new EmbedBuilder()
+                .Title(embedTitle)
                 .Color(DiscordUtils.Gray)
-                .Footer(new($"Since {breakdown.RangeStart.FormatZoned(tz)} ({actualPeriod.FormatDuration()} ago)"));
+                .Footer(new($"System ID: {system.Hid} | {(group != null ? $"Group ID: {group.Hid} | " : "") }Since {breakdown.RangeStart.FormatZoned(tz)} ({actualPeriod.FormatDuration()} ago)"));
 
             var maxEntriesToDisplay = 24; // max 25 fields allowed in embed - reserve 1 for "others"
 

--- a/PluralKit.Core/Services/DataFileService.cs
+++ b/PluralKit.Core/Services/DataFileService.cs
@@ -51,7 +51,7 @@ namespace PluralKit.Core
 
             // Export switches
             var switches = new List<DataFileSwitch>();
-            var switchList = await _repo.GetPeriodFronters(conn, system.Id, Instant.FromDateTimeUtc(DateTime.MinValue.ToUniversalTime()), SystemClock.Instance.GetCurrentInstant());
+            var switchList = await _repo.GetPeriodFronters(conn, system.Id, null, Instant.FromDateTimeUtc(DateTime.MinValue.ToUniversalTime()), SystemClock.Instance.GetCurrentInstant());
             switches.AddRange(switchList.Select(x => new DataFileSwitch
             {
                 Timestamp = x.TimespanStart.FormatExport(),


### PR DESCRIPTION
Added a command that lets you view the frontpercent of a specific group only.
 - Command: `pk;group <group> frontpercent`, with all the aliases the system-wide command has currently
 - Changed the tasks for getting the front breakdown to be compatible with groups
 - Added a title to the embed and added the system/group ID to the footer of it.
 
Basically, the GetPeriodFronters task checks if there's a group specified, and if so it queries a list of the members in the group. It then creates a library from that list. If there is no group specified, it'll just create a library from membersList. When creating the SwitchListEntries it'll check the group library to see if every member matches a member in the group library, and filter out the ones that don't. Then it applies the same math from there.

Here's a screenshot of it in action.
![image](https://user-images.githubusercontent.com/72747870/107545099-2c422e80-6bcb-11eb-87b2-8e4b7dc51b0e.png)

Currently any period of time where no members of the group are switched in will show up as (no fronter), but I'm assuming that's not really an issue