### PR TITLE
Add 'pk;msg <id|link> delete'

### DIFF
--- a/Myriad/Rest/DiscordApiClient.cs
+++ b/Myriad/Rest/DiscordApiClient.cs
@@ -54,7 +54,8 @@ namespace Myriad.Rest
 
         public Task DeleteMessage(ulong channelId, ulong messageId) =>
             _client.Delete($"/channels/{channelId}/messages/{messageId}", ("DeleteMessage", channelId));
-
+        public Task DeleteMessage(Message message) =>
+            _client.Delete($"/channels/{message.ChannelId}/messages/{message.Id}", ("DeleteMessage", message.ChannelId));
         public Task CreateReaction(ulong channelId, ulong messageId, Emoji emoji) =>
             _client.Put<object>($"/channels/{channelId}/messages/{messageId}/reactions/{EncodeEmoji(emoji)}/@me",
                 ("CreateReaction", channelId), null);

--- a/PluralKit.Bot/Commands/CommandTree.cs
+++ b/PluralKit.Bot/Commands/CommandTree.cs
@@ -75,7 +75,7 @@ namespace PluralKit.Bot
         public static Command Export = new Command("export", "export", "Exports system information to a data file");
         public static Command Help = new Command("help", "help", "Shows help information about PluralKit");
         public static Command Explain = new Command("explain", "explain", "Explains the basics of systems and proxying");
-        public static Command Message = new Command("message", "message <id|link>", "Looks up a proxied message");
+        public static Command Message = new Command("message", "message <id|link> [delete]", "Looks up a proxied message");
         public static Command LogChannel = new Command("log channel", "log channel <channel>", "Designates a channel to post proxied messages to");
         public static Command LogChannelClear = new Command("log channel", "log channel -clear", "Clears the currently set log channel");
         public static Command LogEnable = new Command("log enable", "log enable all|<channel> [channel 2] [channel 3...]", "Enables message logging in certain channels");

--- a/PluralKit.Bot/Commands/Misc.cs
+++ b/PluralKit.Bot/Commands/Misc.cs
@@ -222,6 +222,15 @@ namespace PluralKit.Bot {
             var message = await _db.Execute(c => _repo.GetMessage(c, messageId));
             if (message == null) throw Errors.MessageNotFound(messageId);
 
+            if (ctx.Match("delete") || ctx.MatchFlag("delete"))
+            {
+                if (message.System.Id != ctx.System.Id)
+                    throw new PKError("You can only delete your own messages.");
+                await ctx.Rest.DeleteMessage(message.Message.Channel, message.Message.Mid);
+                await ctx.Rest.DeleteMessage(ctx.Message);
+                return;
+            }
+
             await ctx.Reply(embed: await _embeds.CreateMessageInfoEmbed(message));
         }
     }


### PR DESCRIPTION
This is so deleting messages doesn't require any more permissions than sending them (for example, in a channel with reactions disabled)
Also works with flag, as in: `pk;msg --delete <id|link>`