### PR TITLE
fix channel checks missing GuildNews

### DIFF
--- a/PluralKit.Bot/CommandSystem/ContextEntityArgumentsExt.cs
+++ b/PluralKit.Bot/CommandSystem/ContextEntityArgumentsExt.cs
@@ -162,7 +162,7 @@ namespace PluralKit.Bot
             if (!ctx.Cache.TryGetChannel(id, out var channel))
                 return null;
             
-            if (!(channel.Type == Channel.ChannelType.GuildText || channel.Type == Channel.ChannelType.GuildText)) 
+            if (!(DiscordUtils.IsValidGuildChannel(channel))) 
                 return null;
             
             ctx.PopArgument();

--- a/PluralKit.Bot/Handlers/MessageEdited.cs
+++ b/PluralKit.Bot/Handlers/MessageEdited.cs
@@ -45,7 +45,7 @@ namespace PluralKit.Bot
                 return;
             
             var channel = _cache.GetChannel(evt.ChannelId);
-            if (channel.Type != Channel.ChannelType.GuildText)
+            if (!DiscordUtils.IsValidGuildChannel(channel))
                 return;
             var guild = _cache.GetGuild(channel.GuildId!.Value);
 

--- a/PluralKit.Bot/Handlers/ReactionAdded.cs
+++ b/PluralKit.Bot/Handlers/ReactionAdded.cs
@@ -67,7 +67,7 @@ namespace PluralKit.Bot
             }
 
             // Only proxies in guild text channels
-            if (channel.Type != Channel.ChannelType.GuildText) return;
+            if (!DiscordUtils.IsValidGuildChannel(channel)) return;
 
             // Ignore reactions from bots (we can't DM them anyway)
             if (user.Bot) return;

--- a/PluralKit.Bot/Proxy/ProxyService.cs
+++ b/PluralKit.Bot/Proxy/ProxyService.cs
@@ -88,7 +88,7 @@ namespace PluralKit.Bot
             if (ctx.SystemId == null) return false;
             
             // Make sure channel is a guild text channel and this is a normal message
-            if (channel.Type != Channel.ChannelType.GuildText && channel.Type != Channel.ChannelType.GuildNews) return false;
+            if (!DiscordUtils.IsValidGuildChannel(channel)) return false;
             if (msg.Type != Message.MessageType.Default && msg.Type != Message.MessageType.Reply) return false;
             
             // Make sure author is a normal user

--- a/PluralKit.Bot/Services/PeriodicStatCollector.cs
+++ b/PluralKit.Bot/Services/PeriodicStatCollector.cs
@@ -54,7 +54,7 @@ namespace PluralKit.Bot
                 guildCount++;
                 foreach (var channel in _cache.GetGuildChannels(guild.Id))
                 {
-                    if (channel.Type == Channel.ChannelType.GuildText)
+                    if (DiscordUtils.IsValidGuildChannel(channel))
                         channelCount++;
                 }
             }

--- a/PluralKit.Bot/Utils/DiscordUtils.cs
+++ b/PluralKit.Bot/Utils/DiscordUtils.cs
@@ -186,5 +186,8 @@ namespace PluralKit.Bot
 
         public static string EventType(this IGatewayEvent evt) => 
             evt.GetType().Name.Replace("Event", "");
+
+        public static bool IsValidGuildChannel(Channel channel) =>
+            !(channel.Type != Channel.ChannelType.GuildText && channel.Type != Channel.ChannelType.GuildNews);
     }
 }


### PR DESCRIPTION
I left the log channel / log clean checks as-is because i'm assuming nobody's using an announcements channel as their log channel (I hope).