### PR TITLE
Autoproxy scopes

### DIFF
--- a/PluralKit.Bot/CommandSystem/ContextArgumentsExt.cs
+++ b/PluralKit.Bot/CommandSystem/ContextArgumentsExt.cs
@@ -114,5 +114,20 @@ namespace PluralKit.Bot
 
             return groups;
         }
+
+        public static AutoproxyScope MatchAutoproxyScope(this Context ctx)
+        {
+            // TODO: how do we match guild/channel IDs here?
+
+            if (ctx.MatchFlag("global"))
+                return AutoproxyScope.Global;
+            else if (ctx.MatchFlag("server", "guild"))
+                return AutoproxyScope.Guild;
+            else if (ctx.MatchFlag("channel"))
+                return AutoproxyScope.Channel;
+            
+            // default fallback
+            return AutoproxyScope.Guild;
+        }
     }
 }

--- a/PluralKit.Bot/Proxy/ProxyMatcher.cs
+++ b/PluralKit.Bot/Proxy/ProxyMatcher.cs
@@ -56,8 +56,8 @@ namespace PluralKit.Bot
                 AutoproxyMode.Front when ctx.LastSwitchMembers.Length > 0 => 
                     members.FirstOrDefault(m => m.Id == ctx.LastSwitchMembers[0]),
                 
-                AutoproxyMode.Latch when ctx.LastMessageMember != null && !IsLatchExpired(ctx) =>
-                    members.FirstOrDefault(m => m.Id == ctx.LastMessageMember.Value),
+                AutoproxyMode.Latch when ctx.AutoproxyMember != null => // && !IsLatchExpired(ctx) =>
+                    members.FirstOrDefault(m => m.Id == ctx.AutoproxyMember.Value),
                 
                 _ => null
             };

--- a/PluralKit.Core/Database/Database.cs
+++ b/PluralKit.Core/Database/Database.cs
@@ -19,7 +19,7 @@ namespace PluralKit.Core
     internal class Database: IDatabase
     {
         private const string RootPath = "PluralKit.Core.Database"; // "resource path" root for SQL files
-        private const int TargetSchemaVersion = 13;
+        private const int TargetSchemaVersion = 15;
         
         private readonly CoreConfig _config;
         private readonly ILogger _logger;

--- a/PluralKit.Core/Database/Functions/MessageContext.cs
+++ b/PluralKit.Core/Database/Functions/MessageContext.cs
@@ -16,7 +16,9 @@ namespace PluralKit.Core
         public bool LogCleanupEnabled { get; }
         public bool ProxyEnabled { get; }
         public AutoproxyMode AutoproxyMode { get; }
+        public AutoproxyScope AutoproxyScope { get; }
         public MemberId? AutoproxyMember { get; }
+        public ulong AutoproxyLocation { get; }
         public ulong? LastMessage { get; }
         public MemberId? LastMessageMember { get; }
         public SwitchId? LastSwitch { get; }

--- a/PluralKit.Core/Database/Migrations/14.sql
+++ b/PluralKit.Core/Database/Migrations/14.sql
@@ -1,0 +1,2 @@
+-- placeholder
+select 1;

--- a/PluralKit.Core/Database/Migrations/15.sql
+++ b/PluralKit.Core/Database/Migrations/15.sql
@@ -1,0 +1,51 @@
+-- new autoproxy format
+-- allows for global/channel autoproxy, and "un-latching"
+
+-- scope pseudo-enum:
+-- 1: global autoproxy
+-- 2: guild autoproxy (default, current behaviour)
+-- 3: channel autoproxy
+
+-- mode pseudo-enum: (copied from 3.sql)
+-- 1 = autoproxy off
+-- 2 = front mode (first fronter)
+-- 3 = latch mode (last proxyer)
+-- 4 = member mode (specific member)
+
+create table autoproxy
+(
+    system int not null references systems(id) on delete cascade,
+    scope int check (scope in (1, 2, 3)) not null default 2,
+    mode int check (mode in (1, 2, 3, 4)) not null default 1,
+    location bigint,
+    member int references members(id) on delete set null,
+    primary key (system, location)
+);
+
+-- TODO: latch timestamp + update trigger
+
+-- TODO: migrate existing autoproxy data
+-- none of this code works lol
+
+-- with
+--     data as (select system, autoproxy_mode, autoproxy_member, guild from system_guild)
+-- insert into autoproxy 
+--     (system, scope, mode, member, location) values
+--     (data.system, 2, data.autoproxy_mode, data.autoproxy_member, data.guild);
+
+-- with
+--     data as (select system, guild from system_guild where autoproxy_mode = 3),
+-- update autoproxy set 
+--     member = (select member from messages where messages.guild = data.guild order by mid limit 1)
+-- where 
+--     system = data.system and location = data.guild and autoproxy_mode = 3;
+
+-- with data as (select system, guild, autoproxy_member from system_guild where autoproxy_mode = 4)
+--     update autoproxy set member = autoproxy_member where autoproxy.mode = 4 and location = data.guild;
+
+-- drop old columns
+
+alter table system_guild drop column autoproxy_mode;
+alter table system_guild drop column autoproxy_member;
+
+update info set schema_version = 15;

--- a/PluralKit.Core/Database/Repository/ModelRepository.Autoproxy.cs
+++ b/PluralKit.Core/Database/Repository/ModelRepository.Autoproxy.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+
+using Dapper;
+
+namespace PluralKit.Core
+{
+    public partial class ModelRepository
+    {
+        public async Task<AutoproxySettings> UpsertAutoproxySettings(IPKConnection conn, SystemId system, ulong? location, AutoproxyScope scope, AutoproxyPatch patch)
+        {
+            var (query, pms) = patch.Apply(UpdateQueryBuilder.Upsert("autoproxy", "system, location"))
+                .WithConstant("system", system)
+                .WithConstant("scope", scope)
+                // postgres really doesn't like primary keys to be null, so we use zero for global scope
+                // it doesn't really matter since we check scope before location
+                .WithConstant("location", location ?? 0)
+                .Build("returning *");
+            return await conn.QueryFirstAsync<AutoproxySettings>(query, pms);
+        }
+
+        public async Task<AutoproxySettings> GetAutoproxySettings(IPKConnection conn, SystemId system, AutoproxyScope scope, ulong? location) =>
+            await conn.QueryFirstOrDefaultAsync<AutoproxySettings>("select * from autoproxy where system = @System and scope = @Scope and location = @Location", new { System = system, Scope = scope, Location = location ?? 0});
+
+        public async Task ClearAutoproxySettings(IPKConnection conn, SystemId system, AutoproxyScope scope, ulong? location) =>
+            await conn.QueryAsync("delete from autoproxy where system = @System and scope = @Scope and location = @Location", new { System = system, Scope = scope, Location = location});
+    }
+}

--- a/PluralKit.Core/Database/clean.sql
+++ b/PluralKit.Core/Database/clean.sql
@@ -7,6 +7,7 @@ drop view if exists system_fronters;
 drop view if exists member_list;
 drop view if exists group_list;
 
+drop function if exists autoproxy_context;
 drop function if exists message_context;
 drop function if exists proxy_members;
 drop function if exists has_private_members;

--- a/PluralKit.Core/Models/AutoproxySettings.cs
+++ b/PluralKit.Core/Models/AutoproxySettings.cs
@@ -1,0 +1,27 @@
+namespace PluralKit.Core
+{
+    public class AutoproxySettings
+    {
+        public SystemId Id { get; private set; }
+        public AutoproxyMode Mode { get; private set; }
+        public AutoproxyScope Scope { get; private set; }
+        public ulong Location { get; private set; }
+        public MemberId? Member { get; private set; }
+    }
+
+    public enum AutoproxyMode
+    {
+        Off = 1,
+        Front = 2,
+        Latch = 3,
+        Member = 4
+    }
+
+    public enum AutoproxyScope
+    {
+        Global = 1,
+        Guild = 2,
+        Channel = 3,
+    }
+
+}

--- a/PluralKit.Core/Models/Patch/AutoproxyPatch.cs
+++ b/PluralKit.Core/Models/Patch/AutoproxyPatch.cs
@@ -1,0 +1,12 @@
+namespace PluralKit.Core
+{
+	public class AutoproxyPatch: PatchObject
+	{
+
+        public Partial<AutoproxyMode> AutoproxyMode { get; set; }
+        public Partial<MemberId?> AutoproxyMember { get; set; }
+		public override UpdateQueryBuilder Apply(UpdateQueryBuilder b) => b
+            .With("mode", AutoproxyMode)
+            .With("member", AutoproxyMember);
+	}
+}

--- a/PluralKit.Core/Models/Patch/SystemGuildPatch.cs
+++ b/PluralKit.Core/Models/Patch/SystemGuildPatch.cs
@@ -4,12 +4,8 @@ namespace PluralKit.Core
     public class SystemGuildPatch: PatchObject
     {
         public Partial<bool> ProxyEnabled { get; set; }
-        public Partial<AutoproxyMode> AutoproxyMode { get; set; }
-        public Partial<MemberId?> AutoproxyMember { get; set; }
 
         public override UpdateQueryBuilder Apply(UpdateQueryBuilder b) => b
-            .With("proxy_enabled", ProxyEnabled)
-            .With("autoproxy_mode", AutoproxyMode)
-            .With("autoproxy_member", AutoproxyMember);
+            .With("proxy_enabled", ProxyEnabled);
     }
 }

--- a/PluralKit.Core/Models/SystemGuildSettings.cs
+++ b/PluralKit.Core/Models/SystemGuildSettings.cs
@@ -1,12 +1,5 @@
 ﻿namespace PluralKit.Core
 {
-    public enum AutoproxyMode
-    {
-        Off = 1,
-        Front = 2,
-        Latch = 3,
-        Member = 4
-    }
     
     public class SystemGuildSettings
     {
@@ -14,7 +7,5 @@
         public SystemId System { get; }
         public bool ProxyEnabled { get; } = true;
 
-        public AutoproxyMode AutoproxyMode { get; } = AutoproxyMode.Off;
-        public MemberId? AutoproxyMember { get; }
     }
 }


### PR DESCRIPTION
This PR adds support for autoproxy scopes (global/server/channel autoproxy).

It works, but it still needs a lot of work, namely:
- properly showing autoproxy status ("effective settings" vs actual settings for chosen scope)
- migrating existing autoproxy configs
- latch timeout
- selecting a channel or server instead of just acting on the *current* channel or server
- there's some not-great SQL to be refactored
- documentation, documentation, documentation!
- ... and more!