### PR TITLE
Fix matching canary/ptb Discord links

### DIFF
--- a/PluralKit.Bot/Commands/Misc.cs
+++ b/PluralKit.Bot/Commands/Misc.cs
@@ -215,7 +215,7 @@ namespace PluralKit.Bot {
             ulong messageId;
             if (ulong.TryParse(word, out var id))
                 messageId = id;
-            else if (Regex.Match(word, "https://discord(?:app)?.com/channels/\\d+/\\d+/(\\d+)") is Match match && match.Success)
+            else if (Regex.Match(word, "https://(?:\\w+.)discord(?:app)?.com/channels/\\d+/\\d+/(\\d+)") is Match match && match.Success)
                 messageId = ulong.Parse(match.Groups[1].Value);
             else throw new PKSyntaxError($"Could not parse {word.AsCode()} as a message ID or link.");
 


### PR DESCRIPTION
technically the Discord client allows any subdomain to function as a link, even inexistent stuff like `nya.discord.com`, so i just added a `\w+` to the link matching regex