### PR TITLE
Add message editing

### DIFF
--- a/Myriad/Rest/DiscordApiClient.cs
+++ b/Myriad/Rest/DiscordApiClient.cs
@@ -121,6 +121,10 @@ namespace Myriad.Rest
             _client.PostMultipart<Message>($"/webhooks/{webhookId}/{webhookToken}?wait=true",
                 ("ExecuteWebhook", webhookId), request, files)!;
 
+        public Task<Message> EditWebhookMessage(ulong webhookId, string webhookToken, ulong messageId, EditWebhookMessageRequest request) =>
+            _client.Patch<Message>($"/webhooks/{webhookId}/{webhookToken}/messages/{messageId}",
+                ("EditWebhookMessage", webhookId), request)!;
+
         public Task<Channel> CreateDm(ulong recipientId) =>
             _client.Post<Channel>($"/users/@me/channels", ("CreateDM", default), new CreateDmRequest(recipientId))!;
 

--- a/Myriad/Rest/Types/Requests/EditWebhookMessageRequest.cs
+++ b/Myriad/Rest/Types/Requests/EditWebhookMessageRequest.cs
@@ -1,0 +1,11 @@
+using Myriad.Types;
+
+namespace Myriad.Rest.Types.Requests
+{
+    public record EditWebhookMessageRequest
+    {
+        public string Content { get; init; }
+        public Embed[] Embeds { get; init; }
+        public AllowedMentions? AllowedMentions { get; init; }
+    }
+}

--- a/PluralKit.Bot/CommandSystem/Context.cs
+++ b/PluralKit.Bot/CommandSystem/Context.cs
@@ -38,6 +38,7 @@ namespace PluralKit.Bot
         private readonly IMetrics _metrics;
         private readonly CommandMessageService _commandMessageService;
         private readonly IDiscordCache _cache;
+        private readonly WebhookCacheService _webhookCache;
 
         private Command _currentCommand;
 
@@ -51,6 +52,7 @@ namespace PluralKit.Bot
             _senderSystem = senderSystem;
             _messageContext = messageContext;
             _cache = provider.Resolve<IDiscordCache>();
+            _webhookCache = provider.Resolve<WebhookCacheService>();
             _db = provider.Resolve<IDatabase>();
             _repo = provider.Resolve<ModelRepository>();
             _metrics = provider.Resolve<IMetrics>();
@@ -65,6 +67,7 @@ namespace PluralKit.Bot
         }
 
         public IDiscordCache Cache => _cache;
+        public WebhookCacheService WebhookCache => _webhookCache;
 
         public Channel Channel => _channel;
         public User Author => _message.Author;

--- a/PluralKit.Bot/Commands/CommandTree.cs
+++ b/PluralKit.Bot/Commands/CommandTree.cs
@@ -80,6 +80,7 @@ namespace PluralKit.Bot
         public static Command Explain = new Command("explain", "explain", "Explains the basics of systems and proxying");
         public static Command MessageInfo = new Command("message", "message [reply|id|link]", "Looks up a proxied message");
         public static Command MessageDelete = new Command("message", "message [reply|id|link] delete", "Deletes a proxied message.");
+        public static Command MessageEdit = new Command("message", "message [reply|id|link] edit [new message]", "Edits a proxied message");
         public static Command LogChannel = new Command("log channel", "log channel <channel>", "Designates a channel to post proxied messages to");
         public static Command LogChannelClear = new Command("log channel", "log channel -clear", "Clears the currently set log channel");
         public static Command LogEnable = new Command("log enable", "log enable all|<channel> [channel 2] [channel 3...]", "Enables message logging in certain channels");
@@ -122,7 +123,7 @@ namespace PluralKit.Bot
 
         public static Command[] BlacklistCommands = {BlacklistAdd, BlacklistRemove, BlacklistShow};
 
-        public static Command[]MessageCommands = { MessageInfo, MessageDelete };
+        public static Command[]MessageCommands = { MessageInfo, MessageDelete, MessageEdit };
 
         public Task ExecuteCommand(Context ctx)
         {
@@ -163,6 +164,8 @@ namespace PluralKit.Bot
                 return ctx.Execute<Help>(Explain, m => m.Explain(ctx));
             if (ctx.Match("message", "msg"))
                 return HandleMessageCommand(ctx);
+            if (ctx.Match("edit"))
+                return HandleMessageEditCommand(ctx);
             if (ctx.Match("log"))
                 if (ctx.Match("channel"))
                     return ctx.Execute<ServerConfig>(LogChannel, m => m.SetLogChannel(ctx));
@@ -514,6 +517,18 @@ namespace PluralKit.Bot
                 await ctx.Execute<Msg>(MessageInfo, m => m.MessageInfo(ctx, message));
             else if (ctx.Match("delete"))
                 await ctx.Execute<Msg>(MessageDelete, m => m.MessageDelete(ctx, message));
+            else if (ctx.Match("edit"))
+                await ctx.Execute<Msg>(MessageEdit, m => m.MessageEdit(ctx, message));
+        }
+
+        private async Task HandleMessageEditCommand(Context ctx)
+        {
+            FullMessage message = await ctx.MatchMessage();
+
+            if (message == null)
+                throw new PKError("You must reply to a message or pass a message ID or link");
+
+            await ctx.Execute<Msg>(MessageEdit, m => m.MessageEdit(ctx, message));
         }
 
         private async Task PrintCommandNotFoundError(Context ctx, params Command[] potentialCommands)

--- a/PluralKit.Bot/Commands/Misc.cs
+++ b/PluralKit.Bot/Commands/Misc.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 using App.Metrics;
@@ -206,32 +205,6 @@ namespace PluralKit.Bot {
 
             // Send! :)
             await ctx.Reply(embed: eb.Build());
-        }
-        
-        public async Task GetMessage(Context ctx)
-        {
-            var word = ctx.PopArgument() ?? throw new PKSyntaxError("You must pass a message ID or link.");
-
-            ulong messageId;
-            if (ulong.TryParse(word, out var id))
-                messageId = id;
-            else if (Regex.Match(word, "https://(?:\\w+.)discord(?:app)?.com/channels/\\d+/\\d+/(\\d+)") is Match match && match.Success)
-                messageId = ulong.Parse(match.Groups[1].Value);
-            else throw new PKSyntaxError($"Could not parse {word.AsCode()} as a message ID or link.");
-
-            var message = await _db.Execute(c => _repo.GetMessage(c, messageId));
-            if (message == null) throw Errors.MessageNotFound(messageId);
-
-            if (ctx.Match("delete") || ctx.MatchFlag("delete"))
-            {
-                if (message.System.Id != ctx.System.Id)
-                    throw new PKError("You can only delete your own messages.");
-                await ctx.Rest.DeleteMessage(message.Message.Channel, message.Message.Mid);
-                await ctx.Rest.DeleteMessage(ctx.Message);
-                return;
-            }
-
-            await ctx.Reply(embed: await _embeds.CreateMessageInfoEmbed(message));
         }
     }
 }

--- a/PluralKit.Bot/Commands/Msg.cs
+++ b/PluralKit.Bot/Commands/Msg.cs
@@ -1,0 +1,55 @@
+using System.Threading.Tasks;
+
+using App.Metrics;
+
+using PluralKit.Core;
+
+using Myriad.Cache;
+using Myriad.Rest;
+using Myriad.Gateway;
+
+
+namespace PluralKit.Bot {
+    public class Msg
+    {
+        private readonly BotConfig _botConfig;
+        private readonly IMetrics _metrics;
+        private readonly CpuStatService _cpu;
+        private readonly ShardInfoService _shards;
+        private readonly EmbedService _embeds;
+        private readonly IDatabase _db;
+        private readonly ModelRepository _repo;
+        private readonly IDiscordCache _cache;
+        private readonly DiscordApiClient _rest;
+        private readonly Cluster _cluster;
+        private readonly Bot _bot;
+
+        public Msg(BotConfig botConfig, IMetrics metrics, CpuStatService cpu, ShardInfoService shards, EmbedService embeds, ModelRepository repo, IDatabase db, IDiscordCache cache, DiscordApiClient rest, Bot bot, Cluster cluster)
+        {
+            _botConfig = botConfig;
+            _metrics = metrics;
+            _cpu = cpu;
+            _shards = shards;
+            _embeds = embeds;
+            _repo = repo;
+            _db = db;
+            _cache = cache;
+            _rest = rest;
+            _bot = bot;
+            _cluster = cluster;
+        }
+
+        public async Task MessageInfo(Context ctx, FullMessage message)
+        {
+            await ctx.Reply(embed: await _embeds.CreateMessageInfoEmbed(message));
+        }
+
+        public async Task MessageDelete(Context ctx, FullMessage message)
+        {
+            if (message.System.Id != ctx.System?.Id)
+                throw new PKError("You can only delete your own messages.");
+            await ctx.Rest.DeleteMessage(message.Message.Channel, message.Message.Mid);
+            await ctx.Rest.DeleteMessage(ctx.Message);
+        }
+    }
+}

--- a/PluralKit.Bot/Commands/Msg.cs
+++ b/PluralKit.Bot/Commands/Msg.cs
@@ -4,8 +4,10 @@ using App.Metrics;
 
 using PluralKit.Core;
 
+using Myriad.Types;
 using Myriad.Cache;
 using Myriad.Rest;
+using Myriad.Rest.Types.Requests;
 using Myriad.Gateway;
 
 
@@ -49,6 +51,19 @@ namespace PluralKit.Bot {
             if (message.System.Id != ctx.System?.Id)
                 throw new PKError("You can only delete your own messages.");
             await ctx.Rest.DeleteMessage(message.Message.Channel, message.Message.Mid);
+            await ctx.Rest.DeleteMessage(ctx.Message);
+        }
+
+        public async Task MessageEdit(Context ctx, FullMessage message)
+        {
+            if (message.System.Id != ctx.System?.Id)
+                throw new PKError("You can only edit your own messages.");
+
+            var request = new EditWebhookMessageRequest { Content = ctx.RemainderOrNull() ?? "" };
+            Webhook webhook = await ctx.WebhookCache.GetWebhook(message.Message.Channel);
+            await ctx.Rest.EditWebhookMessage(webhook.Id, webhook.Token, message.Message.Mid, request);
+
+            // Edit commands should be deleted.
             await ctx.Rest.DeleteMessage(ctx.Message);
         }
     }

--- a/PluralKit.Bot/Modules.cs
+++ b/PluralKit.Bot/Modules.cs
@@ -63,6 +63,7 @@ namespace PluralKit.Bot
             builder.RegisterType<SystemFront>().AsSelf();
             builder.RegisterType<SystemLink>().AsSelf();
             builder.RegisterType<SystemList>().AsSelf();
+            builder.RegisterType<Msg>().AsSelf();
             builder.RegisterType<Token>().AsSelf();
             
             // Bot core

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -98,6 +98,7 @@ Words in **\<angle brackets>** or **[square brackets]** mean fill-in-the-blank. 
 - `pk;random [-group]` - Shows the info card of a randomly selected member [or group] in your system.
 - `pk;message <reply / message id / message link>` - Looks up information about a proxied message by reply or by its ID or link.
 - `pk;message <reply / message id / message link> delete` - Deletes a proxied message by reply or by its ID or link.
+- `pk;message <reply / message id / message link> edit <new message>` - Edits a proxied message by reply or by its ID or link.
 - `pk;invite` - Sends the bot invite link for PluralKit.
 - `pk;import` - Imports a data file from PluralKit or Tupperbox.
 - `pk;export` - Exports a data file containing your system information.

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -96,7 +96,8 @@ Words in **\<angle brackets>** or **[square brackets]** mean fill-in-the-blank. 
 
 ## Utility
 - `pk;random [-group]` - Shows the info card of a randomly selected member [or group] in your system.
-- `pk;message <message id / message link>` - Looks up information about a proxied message by its message ID or link.
+- `pk;message <reply / message id / message link>` - Looks up information about a proxied message by reply or by its ID or link.
+- `pk;message <reply / message id / message link> delete` - Deletes a proxied message by reply or by its ID or link.
 - `pk;invite` - Sends the bot invite link for PluralKit.
 - `pk;import` - Imports a data file from PluralKit or Tupperbox.
 - `pk;export` - Exports a data file containing your system information.


### PR DESCRIPTION
`pk;message <message> edit <new message>`, or `pk;edit <message> <new message>` for short, where `<message>` can be an ID or link, or can be omitted entirely if the command is sent as a reply to a message. This also makes the existing `pk;message` functionality accept a reply in place of a link or ID.

Closes #283.