### PR TITLE
add "author" subcommand to pk;msg

### DIFF
--- a/PluralKit.Bot/Commands/CommandTree.cs
+++ b/PluralKit.Bot/Commands/CommandTree.cs
@@ -78,7 +78,7 @@ namespace PluralKit.Bot
         public static Command Export = new Command("export", "export", "Exports system information to a data file");
         public static Command Help = new Command("help", "help", "Shows help information about PluralKit");
         public static Command Explain = new Command("explain", "explain", "Explains the basics of systems and proxying");
-        public static Command Message = new Command("message", "message <id|link> [delete]", "Looks up a proxied message");
+        public static Command Message = new Command("message", "message <id|link> [delete|author]", "Looks up a proxied message");
         public static Command LogChannel = new Command("log channel", "log channel <channel>", "Designates a channel to post proxied messages to");
         public static Command LogChannelClear = new Command("log channel", "log channel -clear", "Clears the currently set log channel");
         public static Command LogEnable = new Command("log enable", "log enable all|<channel> [channel 2] [channel 3...]", "Enables message logging in certain channels");

--- a/PluralKit.Bot/Commands/Misc.cs
+++ b/PluralKit.Bot/Commands/Misc.cs
@@ -230,6 +230,16 @@ namespace PluralKit.Bot {
                 await ctx.Rest.DeleteMessage(ctx.Message);
                 return;
             }
+            if (ctx.Match("author") || ctx.MatchFlag("author"))
+            {
+                var user = await _cache.GetOrFetchUser(_rest, message.Message.Sender);
+                var eb = new EmbedBuilder()
+                    .Author(new(user != null ? $"{user.Username}#{user.Discriminator}" : $"Deleted user ${message.Message.Sender}", IconUrl: user != null ? user.AvatarUrl() : null))
+                    .Description(message.Message.Sender.ToString());
+
+                await ctx.Reply(user != null ? $"{user.Mention()} ({user.Id})" : $"*(deleted user {message.Message.Sender})*", embed: eb.Build());
+                return;
+            }
 
             await ctx.Reply(embed: await _embeds.CreateMessageInfoEmbed(message));
         }


### PR DESCRIPTION
For people on mobile who can't get a user's ID from normal `pk;msg`

Like `pk;msg <id> delete`, also works as a flag (`pk;msg --author <id>`)