### PR TITLE
API patch improvements

### DIFF
--- a/PluralKit.API/Controllers/v1/MemberController.cs
+++ b/PluralKit.API/Controllers/v1/MemberController.cs
@@ -104,7 +104,7 @@ namespace PluralKit.API
             }
             catch (InvalidPatchException e)
             {
-                return BadRequest($"Request field is invalid: {e.Message}");
+                return BadRequest($"Request field '{e.Message}' is invalid.");
             }
             
             var newMember = await _repo.UpdateMember(conn, member.Id, patch);

--- a/PluralKit.API/Controllers/v1/MemberController.cs
+++ b/PluralKit.API/Controllers/v1/MemberController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 using Dapper;
@@ -54,18 +55,28 @@ namespace PluralKit.API
             if (memberCount >= memberLimit)
                 return BadRequest($"Member limit reached ({memberCount} / {memberLimit}).");
 
-            var member = await _repo.CreateMember(conn, systemId, properties.Value<string>("name"));
+            await using var tx = await conn.BeginTransactionAsync();
+            var member = await _repo.CreateMember(conn, systemId, properties.Value<string>("name"), transaction: tx);
+
             MemberPatch patch;
             try
             {
                 patch = JsonModelExt.ToMemberPatch(properties);
+                patch.CheckIsValid();
             }
             catch (JsonModelParseError e)
             {
+                await tx.RollbackAsync();
                 return BadRequest(e.Message);
             }
+            catch (InvalidPatchException e)
+            {
+                await tx.RollbackAsync();
+                return BadRequest($"Request field '{e.Message}' is invalid.");
+            }
             
-            member = await _repo.UpdateMember(conn, member.Id, patch);
+            member = await _repo.UpdateMember(conn, member.Id, patch, transaction: tx);
+            await tx.CommitAsync();
             return Ok(member.ToJson(User.ContextFor(member)));
         }
 
@@ -85,10 +96,15 @@ namespace PluralKit.API
             try
             {
                 patch = JsonModelExt.ToMemberPatch(changes);
+                patch.CheckIsValid();
             }
             catch (JsonModelParseError e)
             {
                 return BadRequest(e.Message);
+            }
+            catch (InvalidPatchException e)
+            {
+                return BadRequest($"Request field is invalid: {e.Message}");
             }
             
             var newMember = await _repo.UpdateMember(conn, member.Id, patch);

--- a/PluralKit.API/Controllers/v1/SystemController.cs
+++ b/PluralKit.API/Controllers/v1/SystemController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -140,13 +141,18 @@ namespace PluralKit.API
             try
             {
                 patch = JsonModelExt.ToSystemPatch(changes); 
+                patch.CheckIsValid();
             }
             catch (JsonModelParseError e)
             {
                 return BadRequest(e.Message);
             }
+            catch (InvalidPatchException e)
+            {
+                return BadRequest($"Request field '{e.Message}' is invalid.");
+            }
 
-            await _repo.UpdateSystem(conn, system!.Id, patch);
+            system = await _repo.UpdateSystem(conn, system!.Id, patch);
             return Ok(system.ToJson(User.ContextFor(system)));
         }
 

--- a/PluralKit.Bot/Utils/AvatarUtils.cs
+++ b/PluralKit.Bot/Utils/AvatarUtils.cs
@@ -25,17 +25,8 @@ namespace PluralKit.Bot {
 
             using (var client = new HttpClient())
             {
-                Uri uri;
-                try
-                {
-                    uri = new Uri(url);
-                    if (!uri.IsAbsoluteUri || (uri.Scheme != "http" && uri.Scheme != "https")) 
-                        throw Errors.InvalidUrl(url);
-                }
-                catch (UriFormatException)
-                {
+                if (!PluralKit.Core.MiscUtils.TryMatchUri(url, out var uri))
                     throw Errors.InvalidUrl(url);
-                }
 
                 var response = await client.GetAsync(uri);
                 if (!response.IsSuccessStatusCode) // Check status code

--- a/PluralKit.Core/Models/Patch/GroupPatch.cs
+++ b/PluralKit.Core/Models/Patch/GroupPatch.cs
@@ -1,4 +1,6 @@
 ﻿#nullable enable
+using System.Text.RegularExpressions;
+
 namespace PluralKit.Core
 {
     public class GroupPatch: PatchObject
@@ -24,5 +26,14 @@ namespace PluralKit.Core
             .With("icon_privacy", IconPrivacy)
             .With("list_privacy", ListPrivacy)
             .With("visibility", Visibility);
+
+        public new void CheckIsValid()
+        {
+            if (Icon.Value != null && !MiscUtils.TryMatchUri(Icon.Value, out var avatarUri))
+                throw new InvalidPatchException("avatar_url");
+            if (Color.Value != null && (!Regex.IsMatch(Color.Value, "^[0-9a-fA-F]{6}$")))
+                throw new InvalidPatchException("color");
+        }
+
     }
 }

--- a/PluralKit.Core/Models/Patch/MemberPatch.cs
+++ b/PluralKit.Core/Models/Patch/MemberPatch.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+using System.Text.RegularExpressions;
 
 using NodaTime;
 
@@ -44,5 +45,14 @@ namespace PluralKit.Core
             .With("birthday_privacy", BirthdayPrivacy)
             .With("avatar_privacy", AvatarPrivacy)
             .With("metadata_privacy", MetadataPrivacy);
+
+        public new void CheckIsValid()
+        {
+            if (AvatarUrl.Value != null && !MiscUtils.TryMatchUri(AvatarUrl.Value, out var avatarUri))
+                throw new InvalidPatchException("avatar_url");
+            if (Color.Value != null && (!Regex.IsMatch(Color.Value, "^[0-9a-fA-F]{6}$")))
+                throw new InvalidPatchException("color");
+        }
+
     }
 }

--- a/PluralKit.Core/Models/Patch/PatchObject.cs
+++ b/PluralKit.Core/Models/Patch/PatchObject.cs
@@ -1,7 +1,17 @@
-﻿namespace PluralKit.Core
+﻿using System;
+
+namespace PluralKit.Core
 {
+
+    public class InvalidPatchException : Exception
+    {
+        public InvalidPatchException(string message) : base(message) {}
+    }
+
     public abstract class PatchObject
     {
         public abstract UpdateQueryBuilder Apply(UpdateQueryBuilder b);
+
+        public void CheckIsValid() {}
     }
 }

--- a/PluralKit.Core/Models/Patch/SystemPatch.cs
+++ b/PluralKit.Core/Models/Patch/SystemPatch.cs
@@ -1,4 +1,6 @@
 ﻿#nullable enable
+using System.Text.RegularExpressions;
+
 namespace PluralKit.Core
 {
     public class SystemPatch: PatchObject
@@ -33,5 +35,14 @@ namespace PluralKit.Core
             .With("front_history_privacy", FrontHistoryPrivacy)
             .With("pings_enabled", PingsEnabled)
             .With("latch_timeout", LatchTimeout);
+
+        public new void CheckIsValid()
+        {
+            if (AvatarUrl.Value != null && !MiscUtils.TryMatchUri(AvatarUrl.Value, out var avatarUri))
+                throw new InvalidPatchException("avatar_url");
+            if (Color.Value != null && (!Regex.IsMatch(Color.Value, "^[0-9a-fA-F]{6}$")))
+                throw new InvalidPatchException("color");
+        }
+
     }
 }

--- a/PluralKit.Core/Utils/MiscUtils.cs
+++ b/PluralKit.Core/Utils/MiscUtils.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace PluralKit.Core
+{
+    public static class MiscUtils
+    {
+        public static bool TryMatchUri(string input, out Uri uri)
+        {
+            try
+            {
+                uri = new Uri(input);
+                if (!uri.IsAbsoluteUri || (uri.Scheme != "http" && uri.Scheme != "https")) 
+                    return false;
+            }
+            catch (UriFormatException)
+            {
+                uri = null;
+                return false;
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
- add PatchObject.CheckIsValid
- use transaction when creating member, as to not create a member if the
patch is invalid
- return edited system in `PATCH /s` endpoint