### PR TITLE
Add flag to remove 'no fronter' item on frontpercent card

### DIFF
--- a/PluralKit.Bot/Commands/Groups.cs
+++ b/PluralKit.Bot/Commands/Groups.cs
@@ -499,8 +499,9 @@ namespace PluralKit.Bot
             else
                 title.Append($"`{targetSystem.Hid}`");
 
+            var ignoreNoFronters = ctx.MatchFlag("fo", "fronters-only");
             var frontpercent = await _db.Execute(c => _repo.GetFrontBreakdown(c, targetSystem.Id, target.Id, rangeStart.Value.ToInstant(), now));
-            await ctx.Reply(embed: await _embeds.CreateFrontPercentEmbed(frontpercent, targetSystem, target, targetSystem.Zone, ctx.LookupContextFor(targetSystem), title.ToString()));
+            await ctx.Reply(embed: await _embeds.CreateFrontPercentEmbed(frontpercent, targetSystem, target, targetSystem.Zone, ctx.LookupContextFor(targetSystem), title.ToString(), ignoreNoFronters));
         }
 
         private async Task<PKSystem> GetGroupSystem(Context ctx, PKGroup target, IPKConnection conn)

--- a/PluralKit.Bot/Commands/SystemFront.cs
+++ b/PluralKit.Bot/Commands/SystemFront.cs
@@ -131,8 +131,9 @@ namespace PluralKit.Bot
             else
                 title.Append($"`{system.Hid}`");
 
+            var ignoreNoFronters = ctx.MatchFlag("fo", "fronters-only");
             var frontpercent = await _db.Execute(c => _repo.GetFrontBreakdown(c, system.Id, null, rangeStart.Value.ToInstant(), now));
-            await ctx.Reply(embed: await _embeds.CreateFrontPercentEmbed(frontpercent, system, null, system.Zone, ctx.LookupContextFor(system), title.ToString()));
+            await ctx.Reply(embed: await _embeds.CreateFrontPercentEmbed(frontpercent, system, null, system.Zone, ctx.LookupContextFor(system), title.ToString(), ignoreNoFronters));
         }
     }
 }

--- a/docs/content/tips-and-tricks.md
+++ b/docs/content/tips-and-tricks.md
@@ -62,3 +62,9 @@ You cannot look up private members of another system.
 |-with-message-count|-wmc|Show each member's message count|
 |-with-created|-wc|Show each member's creation date|
 |-with-avatar|-wa, -wi, -ia, -ii, -img|Show each member's avatar URL|
+
+## Miscellaneous flags
+|Command|Flag|Aliases|Description|
+|---|---|---|---|
+|pk;system frontpercent|fronters-only|fo|Hides the "no fronters" list item|
+|pk;group \<group> frontpercent|fronters-only|fo|Same as above, but for groups|


### PR DESCRIPTION
The flag is called `fronters-only`, or `fo`. (it's the best I could think of, if anyone has better ideas please do let me know.)