### PR TITLE
Add switch editing functionality

### DIFF
--- a/PluralKit.Bot/Commands/CommandTree.cs
+++ b/PluralKit.Bot/Commands/CommandTree.cs
@@ -69,6 +69,8 @@ namespace PluralKit.Bot
         public static Command SwitchOut = new Command("switch out", "switch out", "Registers a switch with no members");
         public static Command SwitchMove = new Command("switch move", "switch move <date/time>", "Moves the latest switch in time");
         public static Command SwitchDelete = new Command("switch delete", "switch delete", "Deletes the latest switch");
+        public static Command SwitchEdit = new Command("switch edit", "switch edit <member> [member 2] [member 3...]", "Edits the members in the latest switch");
+        public static Command SwitchEditOut = new Command("switch edit out", "switch edit out", "Turns the latest switch into a switch-out");
         public static Command SwitchDeleteAll = new Command("switch delete", "switch delete all", "Deletes all logged switches");
         public static Command Link = new Command("link", "link <account>", "Links your system to another account");
         public static Command Unlink = new Command("unlink", "unlink [account]", "Unlinks your system from an account");
@@ -114,7 +116,7 @@ namespace PluralKit.Bot
             GroupDelete, GroupMemberRandom, GroupFrontPercent
         };
 
-        public static Command[] SwitchCommands = {Switch, SwitchOut, SwitchMove, SwitchDelete, SwitchDeleteAll};
+        public static Command[] SwitchCommands = {Switch, SwitchOut, SwitchMove, SwitchEdit, SwitchEditOut, SwitchDelete, SwitchDeleteAll};
 
         public static Command[] AutoproxyCommands = {AutoproxySet, AutoproxyTimeout, AutoproxyAccount};
         
@@ -428,12 +430,17 @@ namespace PluralKit.Bot
                 await ctx.Execute<Switch>(SwitchMove, m => m.SwitchMove(ctx));
             else if (ctx.Match("delete", "remove", "erase", "cancel", "yeet"))
                 await ctx.Execute<Switch>(SwitchDelete, m => m.SwitchDelete(ctx));
+            else if (ctx.Match("edit", "replace"))
+              if (ctx.Match("out"))
+                  await ctx.Execute<Switch>(SwitchEditOut, m => m.SwitchEditOut(ctx));
+              else
+                  await ctx.Execute<Switch>(SwitchEdit, m => m.SwitchEdit(ctx));
             else if (ctx.Match("commands", "help"))
                 await PrintCommandList(ctx, "switching", SwitchCommands);
             else if (ctx.HasNext()) // there are following arguments
                 await ctx.Execute<Switch>(Switch, m => m.SwitchDo(ctx));
             else
-                await PrintCommandNotFoundError(ctx, Switch, SwitchOut, SwitchMove, SwitchDelete, SystemFronter, SystemFrontHistory);
+                await PrintCommandNotFoundError(ctx, Switch, SwitchOut, SwitchMove, SwitchEdit, SwitchEditOut, SwitchDelete, SystemFronter, SystemFrontHistory);
         }
 
         private async Task CommandHelpRoot(Context ctx)

--- a/PluralKit.Bot/Commands/Switch.cs
+++ b/PluralKit.Bot/Commands/Switch.cs
@@ -152,7 +152,7 @@ namespace PluralKit.Bot
 
             // Tell the user the edit suceeded
             if (members.Count == 0)
-              await ctx.Reply($"{Emojis.Success} Switch edited. No one is now fronting.");
+              await ctx.Reply($"{Emojis.Success} Switch edited. The latest switch is now a switch-out.");
             else
               await ctx.Reply($"{Emojis.Success} Switch edited. Current fronter is now {newSwitchMemberStr}.");
         }

--- a/PluralKit.Bot/Errors.cs
+++ b/PluralKit.Bot/Errors.cs
@@ -84,6 +84,7 @@ namespace PluralKit.Bot {
 
         public static PKError SwitchMoveBeforeSecondLast(ZonedDateTime time) => new PKError($"Can't move switch to before last switch time ({time.FormatZoned()}), as it would cause conflicts.");
         public static PKError SwitchMoveCancelled => new PKError("Switch move cancelled.");
+        public static PKError SwitchEditCancelled => new PKError("Switch edit cancelled.");
         public static PKError SwitchDeleteCancelled => new PKError("Switch deletion cancelled.");
         public static PKError TimezoneParseError(string timezone) => new PKError($"Could not parse timezone offset {timezone}. Offset must be a value like 'UTC+5' or 'GMT-4:30'.");
 

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -74,10 +74,11 @@ Words in **\<angle brackets>** or **[square brackets]** mean fill-in-the-blank. 
 
 ## Switching commands
 - `pk;switch [member...]` - Registers a switch with the given members.
+- `pk;switch out` - Registers a 'switch-out' - a switch with no associated members.
 - `pk;switch move <time>` - Moves the latest switch backwards in time.
+- `pk;switch edit [member...|out]` - Edits the members in the latest switch.
 - `pk;switch delete` - Deletes the latest switch.
 - `pk;switch delete all` - Deletes all logged switches.
-- `pk;switch out` - Registers a 'switch-out' - a switch with no associated members.
 
 ## Autoproxy commands
 - `pk;autoproxy [off|front|latch|<member>]` - Sets your system's autoproxy mode for the current server.


### PR DESCRIPTION
This commit adds the commands `pk;sw edit [member ...]` and `pk;sw edit out`, which change the list of members in the latest switch. To make it work, I had to teach the database repository how to edit a switch. I also made the necessary conforming changes to `CommandTree` and the documentation.

Advice on how to improve this is extremely welcome. I had a lot of trouble deciding on the subjective bits (names, documentation strings, etc.). I wouldn't be surprised if I messed up some of the other stuff too. I'm happy to work to fix any problems.