### PR TITLE
message logging tweaks

### DIFF
--- a/PluralKit.Bot/Commands/MessageEdit.cs
+++ b/PluralKit.Bot/Commands/MessageEdit.cs
@@ -44,15 +44,16 @@ namespace PluralKit.Bot
             var newContent = ctx.RemainderOrNull();
 
             var originalMsg = await _rest.GetMessage(msg.Channel, msg.Mid);
+            if (originalMsg == null) throw new PKError("Could not edit message.");
 
             try
             {
-                await _webhookExecutor.EditWebhookMessage(msg.Channel, msg.Mid, newContent);
+                var newMessage = await _webhookExecutor.EditWebhookMessage(msg.Channel, msg.Mid, newContent);
                 
                 if (ctx.BotPermissions.HasFlag(PermissionSet.ManageMessages))
                     await _rest.DeleteMessage(ctx.Channel.Id, ctx.Message.Id);
 
-                await _logChannel.LogEditedMessage(ctx.MessageContext, msg, ctx.Message, originalMsg!, newContent);
+                await _logChannel.LogMessage(ctx.MessageContext, msg, ctx.Message, newMessage, originalMsg.Content!);
             }
             catch (NotFoundException)
             {

--- a/PluralKit.Bot/Proxy/ProxyService.cs
+++ b/PluralKit.Bot/Proxy/ProxyService.cs
@@ -207,7 +207,7 @@ namespace PluralKit.Bot
                                                       Message triggerMessage, Message proxyMessage,
                                                       ProxyMatch match)
         {
-            Task SaveMessageInDatabase() => _repo.AddMessage(conn, new PKMessage
+            var proxiedMessage = new PKMessage
             {
                 Channel = triggerMessage.ChannelId,
                 Guild = triggerMessage.GuildId,
@@ -215,9 +215,11 @@ namespace PluralKit.Bot
                 Mid = proxyMessage.Id,
                 OriginalMid = triggerMessage.Id,
                 Sender = triggerMessage.Author.Id
-            });
+            };
+
+            Task SaveMessageInDatabase() => _repo.AddMessage(conn, proxiedMessage);
             
-            Task LogMessageToChannel() => _logChannel.LogMessage(ctx, match, triggerMessage, proxyMessage.Id).AsTask();
+            Task LogMessageToChannel() => _logChannel.LogMessage(ctx, proxiedMessage, triggerMessage, proxyMessage).AsTask();
             
             async Task DeleteProxyTriggerMessage()
             {

--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -99,26 +99,26 @@ namespace PluralKit.Bot {
             return eb.Build();
         }
 
-        public Embed CreateLoggedMessageEmbed(PKSystem system, PKMember member, ulong messageId, ulong originalMsgId, User sender, string content, Channel channel) {
+        public Embed CreateLoggedMessageEmbed(MessageContext ctx, PKSystem system, PKMember member, ProxyMatch proxy, ulong messageId, ulong originalMsgId, User sender, string content, Channel channel) {
             // TODO: pronouns in ?-reacted response using this card
             var timestamp = DiscordUtils.SnowflakeToInstant(messageId);
-            var name = member.NameFor(LookupContext.ByNonOwner); 
+            var name = proxy.Member.ProxyName(ctx);
             return new EmbedBuilder()
-                .Author(new($"#{channel.Name}: {name}", IconUrl: DiscordUtils.WorkaroundForUrlBug(member.AvatarFor(LookupContext.ByNonOwner))))
-                .Thumbnail(new(member.AvatarFor(LookupContext.ByNonOwner)))
+                .Author(new($"#{channel.Name}: {name}", IconUrl: DiscordUtils.WorkaroundForUrlBug(proxy.Member.ProxyAvatar(ctx))))
+                .Thumbnail(new(proxy.Member.ProxyAvatar(ctx)))
                 .Description(content?.NormalizeLineEndSpacing())
                 .Footer(new($"System ID: {system.Hid} | Member ID: {member.Hid} | Sender: {sender.Username}#{sender.Discriminator} ({sender.Id}) | Message ID: {messageId} | Original Message ID: {originalMsgId}"))
                 .Timestamp(timestamp.ToDateTimeOffset().ToString("O"))
                 .Build();
         }
 
-        public Embed CreateEditedMessageEmbed(PKSystem system, PKMember member, ulong messageId, ulong originalMsgId, User sender, string content, string oldContent, Channel channel) {
+        public Embed CreateEditedMessageEmbed(MessageContext ctx, PKSystem system, PKMember member, ulong messageId, ulong originalMsgId, User sender, string content, Message oldMessage, Channel channel) {
             var timestamp = DiscordUtils.SnowflakeToInstant(messageId);
-            var name = member.NameFor(LookupContext.ByNonOwner); 
+            var name = oldMessage.Author.Username;
             return new EmbedBuilder()
-                .Author(new($"[Edited] #{channel.Name}: {name}", IconUrl: DiscordUtils.WorkaroundForUrlBug(member.AvatarFor(LookupContext.ByNonOwner))))
-                .Thumbnail(new(member.AvatarFor(LookupContext.ByNonOwner)))
-                .Field(new("Old message", oldContent?.NormalizeLineEndSpacing().Truncate(1000)))
+                .Author(new($"[Edited] #{channel.Name}: {name}", IconUrl: DiscordUtils.WorkaroundForUrlBug(oldMessage.Author.AvatarUrl())))
+                .Thumbnail(new(oldMessage.Author.AvatarUrl()))
+                .Field(new("Old message", oldMessage.Content?.NormalizeLineEndSpacing().Truncate(1000)))
                 .Description(content?.NormalizeLineEndSpacing())
                 .Footer(new($"System ID: {system.Hid} | Member ID: {member.Hid} | Sender: {sender.Username}#{sender.Discriminator} ({sender.Id}) | Message ID: {messageId} | Original Message ID: {originalMsgId}"))
                 .Timestamp(timestamp.ToDateTimeOffset().ToString("O"))

--- a/PluralKit.Bot/Services/LogChannelService.cs
+++ b/PluralKit.Bot/Services/LogChannelService.cs
@@ -42,8 +42,8 @@ namespace PluralKit.Bot {
             
             // Send embed!
             await using var conn = await _db.Obtain();
-            var embed = _embed.CreateLoggedMessageEmbed(await _repo.GetSystem(conn, ctx.SystemId.Value), 
-                await _repo.GetMember(conn, proxy.Member.Id), hookMessage, trigger.Id, trigger.Author, proxy.Content, 
+            var embed = _embed.CreateLoggedMessageEmbed(ctx, await _repo.GetSystem(conn, ctx.SystemId.Value),
+                await _repo.GetMember(conn, proxy.Member.Id), proxy, hookMessage, trigger.Id, trigger.Author, proxy.Content,
                 triggerChannel);
             var url = $"https://discord.com/channels/{trigger.GuildId}/{trigger.ChannelId}/{hookMessage}";
             await _rest.CreateMessage(logChannel.Id, new() {Content = url, Embed = embed});
@@ -58,8 +58,8 @@ namespace PluralKit.Bot {
             
             // Send embed!
             await using var conn = await _db.Obtain();
-            var embed = _embed.CreateEditedMessageEmbed(await _repo.GetSystem(conn, ctx.SystemId.Value), 
-                await _repo.GetMember(conn, proxy.Member), originalMessage.Id, trigger.Id, trigger.Author, newContent, originalMessage.Content,
+            var embed = _embed.CreateEditedMessageEmbed(ctx, await _repo.GetSystem(conn, ctx.SystemId.Value),
+                await _repo.GetMember(conn, proxy.Member), originalMessage.Id, trigger.Id, trigger.Author, newContent, originalMessage,
                 triggerChannel);
             var url = $"https://discord.com/channels/{proxy.Guild.Value}/{proxy.Channel}/{proxy.Mid}";
             await _rest.CreateMessage(logChannel.Id, new() {Content = url, Embed = embed});


### PR DESCRIPTION
- use name/avatar from sent message instead of fetching it from `LookupContext.ByNonOwner` (which might be different from the actual proxied message)
- deduplicate code between normal logging and edited message logging