### PR TITLE
Tweak -raw usage

### DIFF
--- a/PluralKit.Bot/CommandSystem/ContextArgumentsExt.cs
+++ b/PluralKit.Bot/CommandSystem/ContextArgumentsExt.cs
@@ -71,6 +71,12 @@ namespace PluralKit.Bot
             return matched;
         }
 
+        public static bool MatchRaw(this Context ctx)
+        {
+            var matched = ctx.Match("r", "raw") || ctx.MatchFlag("r", "raw");
+            return matched;
+        }
+
         public static ulong? MatchMessage(this Context ctx, bool parseRawMessageId)
         {
             if (ctx.Message.Type == Message.MessageType.Reply && ctx.Message.MessageReference != null)

--- a/PluralKit.Bot/Commands/Groups.cs
+++ b/PluralKit.Bot/Commands/Groups.cs
@@ -163,9 +163,6 @@ namespace PluralKit.Bot
             } 
             else if (!ctx.HasNext())
             {
-                if (!target.DescriptionPrivacy.CanAccess(ctx.LookupContextFor(target.System)))
-                    throw Errors.LookupNotAllowed;
-
                 if (target.Description == null)
                     if (ctx.System?.Id == target.System)
                         await ctx.Reply($"This group does not have a description set. To set one, type `pk;group {target.Reference()} description <description>`.");

--- a/PluralKit.Bot/Commands/MemberEdit.cs
+++ b/PluralKit.Bot/Commands/MemberEdit.cs
@@ -115,7 +115,18 @@ namespace PluralKit.Bot
                 var patch = new MemberPatch {Pronouns = Partial<string>.Null()};
                 await _db.Execute(conn => _repo.UpdateMember(conn, target.Id, patch));
                 await ctx.Reply($"{Emojis.Success} Member pronouns cleared.");
-            } 
+            }
+            else if (ctx.MatchRaw())
+            {
+                if (!target.PronounPrivacy.CanAccess(ctx.LookupContextFor(target.System)))
+                    throw Errors.LookupNotAllowed;
+                if (target.Pronouns == null)
+                    if (ctx.System?.Id == target.System)
+                        await ctx.Reply($"This member does not have pronouns set. To set some, type `pk;member {target.Reference()} pronouns <pronouns>`.");
+                    else
+                        await ctx.Reply("This member does not have pronouns set.");
+                else await ctx.Reply($"```\n{target.Pronouns}\n```");
+            }
             else if (!ctx.HasNext())
             {
                 if (!target.PronounPrivacy.CanAccess(ctx.LookupContextFor(target.System)))
@@ -125,8 +136,6 @@ namespace PluralKit.Bot
                         await ctx.Reply($"This member does not have pronouns set. To set some, type `pk;member {target.Reference()} pronouns <pronouns>`.");
                     else
                         await ctx.Reply("This member does not have pronouns set.");
-                else if (ctx.MatchFlag("r", "raw"))
-                    await ctx.Reply($"```\n{target.Pronouns}\n```");
                 else
                     await ctx.Reply($"**{target.NameFor(ctx)}**'s pronouns are **{target.Pronouns}**.\nTo print the pronouns with formatting, type `pk;member {target.Reference()} pronouns -raw`."
                         + (ctx.System?.Id == target.System ? $" To clear them, type `pk;member {target.Reference()} pronouns -clear`." : ""));

--- a/PluralKit.Bot/Commands/SystemEdit.cs
+++ b/PluralKit.Bot/Commands/SystemEdit.cs
@@ -38,6 +38,15 @@ namespace PluralKit.Bot
                 return;
             }
 
+            if (ctx.MatchRaw())
+            {
+                if (ctx.System.Name == null)
+                    await ctx.Reply("Your system currently does not have a name. Type `pk;system name <name>` to set one.");
+                else
+                    await ctx.Reply($"```\n{ctx.System.Name}\n```");
+                return;
+            }
+
             var newSystemName = ctx.RemainderOrNull();
             if (newSystemName == null)
             {
@@ -68,14 +77,21 @@ namespace PluralKit.Bot
                 await ctx.Reply($"{Emojis.Success} System description cleared.");
                 return;
             }
+
+            if (ctx.MatchRaw())
+            {
+                if (ctx.System.Description == null)
+                    await ctx.Reply("Your system does not have a description set. To set one, type `pk;s description <description>`.");
+                else
+                    await ctx.Reply($"```\n{ctx.System.Description}\n```");
+                return;
+            }
             
             var newDescription = ctx.RemainderOrNull()?.NormalizeLineEndSpacing();
             if (newDescription == null)
             {
                 if (ctx.System.Description == null)
                     await ctx.Reply("Your system does not have a description set. To set one, type `pk;s description <description>`.");
-                else if (ctx.MatchFlag("r", "raw"))
-                    await ctx.Reply($"```\n{ctx.System.Description}\n```");
                 else
                     await ctx.Reply(embed: new EmbedBuilder()
                         .Title("System description")
@@ -145,7 +161,15 @@ namespace PluralKit.Bot
                 await _db.Execute(conn => _repo.UpdateSystem(conn, ctx.System.Id, patch));
                 
                 await ctx.Reply($"{Emojis.Success} System tag cleared.");
-            } else if (!ctx.HasNext(skipFlags: false))
+            } 
+            else if (ctx.MatchRaw())
+            {
+                if (ctx.System.Tag == null)
+                    await ctx.Reply($"You currently have no system tag. To set one, type `pk;s tag <tag>`.");
+                else
+                    await ctx.Reply($"```\n{ctx.System.Tag}\n```");
+            }
+            else if (!ctx.HasNext(skipFlags: false))
             {
                 if (ctx.System.Tag == null)
                     await ctx.Reply($"You currently have no system tag. To set one, type `pk;s tag <tag>`.");


### PR DESCRIPTION
This PR does a couple of things:

- MatchRaw in ContextArgumentExt checks for -r and -raw with and without the dash now.
- All the commands that checked for a -raw flag now use MatchRaw instead
- Some more fields like the system tag are able to be printed using -raw now