### PR TITLE
Import/export improvements

### DIFF
--- a/PluralKit.Bot/Commands/ImportExport.cs
+++ b/PluralKit.Bot/Commands/ImportExport.cs
@@ -89,7 +89,10 @@ namespace PluralKit.Bot
                     else
                     {
                         // We already had a system, so show them what changed
-                        await ctx.Reply($"{Emojis.Success} Updated {result.ModifiedNames.Count} members, created {result.AddedNames.Count} members. Type `pk;system list` to check!");
+                        if (result.AddedGroupNames.Count > 0 || result.ModifiedGroupNames.Count > 0)
+                            await ctx.Reply($"{Emojis.Success} Updated {result.ModifiedNames.Count} members, created {result.AddedNames.Count} members; updated {result.ModifiedGroupNames.Count} groups, created {result.AddedGroupNames.Count} groups.");
+                        else
+                            await ctx.Reply($"{Emojis.Success} Updated {result.ModifiedNames.Count} members, created {result.AddedNames.Count} members. Type `pk;system list` to check!");
                     }
                 }
             });

--- a/PluralKit.Core/Database/Views/ListedGroup.cs
+++ b/PluralKit.Core/Database/Views/ListedGroup.cs
@@ -1,7 +1,9 @@
-﻿namespace PluralKit.Core
+﻿using Newtonsoft.Json;
+
+namespace PluralKit.Core
 {
     public class ListedGroup : PKGroup
     {
-        public int MemberCount { get; }
+        [JsonIgnore] public int MemberCount { get; }
     }
 }

--- a/PluralKit.Core/Models/PKGroup.cs
+++ b/PluralKit.Core/Models/PKGroup.cs
@@ -1,26 +1,53 @@
-﻿using NodaTime;
+﻿using System.Text.RegularExpressions;
+
+using Newtonsoft.Json;
+
+using NodaTime;
 
 #nullable enable
 namespace PluralKit.Core
 {
     public class PKGroup
     {
-        public GroupId Id { get; private set; }
-        public string Hid { get; private set; } = null!;
-        public SystemId System { get; private set; }
+        [JsonIgnore] public GroupId Id { get; private set; }
+        [JsonProperty("id")] public string Hid { get; private set; } = null!;
+        [JsonIgnore] public SystemId System { get; private set; }
 
-        public string Name { get; private set; } = null!;
-        public string? DisplayName { get; private set; }
-        public string? Description { get; private set; }
-        public string? Icon { get; private set; }
-        public string? Color { get; private set; }
+        [JsonProperty("name")] public string Name { get; private set; } = null!;
+        [JsonProperty("display_name")] public string? DisplayName { get; private set; }
+        [JsonProperty("description")] public string? Description { get; private set; }
+        [JsonProperty("icon")] public string? Icon { get; private set; }
+        [JsonProperty("color")] public string? Color { get; private set; }
 
-        public PrivacyLevel DescriptionPrivacy { get; private set; }
-        public PrivacyLevel IconPrivacy { get; private set; }
-        public PrivacyLevel ListPrivacy { get; private set; }
-        public PrivacyLevel Visibility { get; private set; }
+        [JsonProperty("description_privacy")] public PrivacyLevel DescriptionPrivacy { get; private set; }
+        [JsonProperty("icon_privacy")] public PrivacyLevel IconPrivacy { get; private set; }
+        [JsonProperty("list_privacy")] public PrivacyLevel ListPrivacy { get; private set; }
+        [JsonProperty("visibility")] public PrivacyLevel Visibility { get; private set; }
         
         public Instant Created { get; private set; }
+
+        public bool Valid =>
+            Name != null &&
+            !Name.IsLongerThan(Limits.MaxGroupNameLength) &&
+            !DisplayName.IsLongerThan(Limits.MaxGroupNameLength) &&
+            !Description.IsLongerThan(Limits.MaxDescriptionLength) &&
+            (Color == null || Regex.IsMatch(Color, "[0-9a-fA-F]{6}")) &&
+
+            // sanity checks
+            !Icon.IsLongerThan(1000);
+
+        public GroupPatch ToGroupPatch() => new GroupPatch
+        {
+            Name = Name,
+            DisplayName = DisplayName,
+            Description = Description,
+            Icon = Icon,
+            Color = Color,
+            DescriptionPrivacy = DescriptionPrivacy,
+            IconPrivacy = IconPrivacy,
+            ListPrivacy = ListPrivacy,
+            Visibility = Visibility,
+        };
     }
 
     public static class PKGroupExt

--- a/PluralKit.Core/Models/PKMember.cs
+++ b/PluralKit.Core/Models/PKMember.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 using Newtonsoft.Json;
 
@@ -10,30 +12,36 @@ namespace PluralKit.Core {
     {
         // Dapper *can* figure out mapping to getter-only properties, but this doesn't work
         // when trying to map to *subclasses* (eg. ListedMember). Adding private setters makes it work anyway.
-        public MemberId Id { get; private set; }
-        public string Hid { get; private set; }
-        public SystemId System { get; private set; }
-        public string Color { get; private set; }
-        public string AvatarUrl { get; private set; }
-        public string Name { get; private set; }
-        public string DisplayName { get; private set; }
-        public LocalDate? Birthday { get; private set; }
-        public string Pronouns { get; private set; }
-        public string Description { get; private set; }
-        public ICollection<ProxyTag> ProxyTags { get; private set; }
-        public bool KeepProxy { get; private set; }
-        public Instant Created { get; private set; }
-        public int MessageCount { get; private set; }
-        public bool AllowAutoproxy { get; private set; }
+        
+        // though apparently we're setting stuff to public for DataFileService so that's not an issue anymore
+        [JsonIgnore] public MemberId Id { get; set; }
+        [JsonProperty("id")] public string Hid { get; set; }
+        [JsonIgnore] public SystemId System { get; set; }
+        [JsonProperty("color")] public string Color { get; set; }
+        [JsonProperty("avatar_url")] public string AvatarUrl { get; set; }
+        [JsonProperty("name")] public string Name { get; set; } 
+        [JsonProperty("display_name")] public string DisplayName { get; set; }
+        [JsonProperty("birthday")] public LocalDate? Birthday { get; set; }
+        [JsonProperty("pronouns")] public string Pronouns { get; set; }
+        [JsonProperty("description")] public string Description { get; set; }
+        [JsonProperty("proxy_tags")] public ICollection<ProxyTag> ProxyTags { get; set; }
+        [JsonProperty("keep_proxy")] public bool KeepProxy { get; set; }
+        [JsonProperty("created")] public Instant Created { get; set; }
+        [JsonProperty("message_count")] public int MessageCount { get; set; }
+        [JsonProperty("allow_autoproxy")] public bool AllowAutoproxy { get; set; }
 
-        public PrivacyLevel MemberVisibility { get; private set; }
-        public PrivacyLevel DescriptionPrivacy { get; private set; }
-        public PrivacyLevel AvatarPrivacy { get; private set; }
-        public PrivacyLevel NamePrivacy { get; private set; } //ignore setting if no display name is set
-        public PrivacyLevel BirthdayPrivacy { get; private set; }
-        public PrivacyLevel PronounPrivacy { get; private set; }
-        public PrivacyLevel MetadataPrivacy { get; private set; }
+        [JsonProperty("visibility")] public PrivacyLevel MemberVisibility { get; set; }
+        [JsonProperty("description_privacy")] public PrivacyLevel DescriptionPrivacy { get; set; }
+        [JsonProperty("avatar_privacy")] public PrivacyLevel AvatarPrivacy { get; set; }
+        [JsonProperty("name_privacy")] public PrivacyLevel NamePrivacy { get; set; } //ignore setting if no display name is set
+        [JsonProperty("birthday_privacy")] public PrivacyLevel BirthdayPrivacy { get; set; }
+        [JsonProperty("pronoun_privacy")] public PrivacyLevel PronounPrivacy { get; set; }
+        [JsonProperty("metadata_privacy")] public PrivacyLevel MetadataPrivacy { get; set; }
         // public PrivacyLevel ColorPrivacy { get; private set; }
+        
+        // legacy, for old exports
+        [JsonProperty("prefix")] [JsonIgnore] private string Prefix { get; set; }
+        [JsonProperty("suffix")] [JsonIgnore] private string Suffix { get; set; }
         
         /// Returns a formatted string representing the member's birthday, taking into account that a year of "0001" or "0004" is hidden
         /// Before Feb 10 2020, the sentinel year was 0001, now it is 0004.
@@ -50,6 +58,43 @@ namespace PluralKit.Core {
         }
 
         [JsonIgnore] public bool HasProxyTags => ProxyTags.Count > 0;
+        
+        [JsonIgnore] public bool Valid =>
+            Name != null &&
+            !Name.IsLongerThan(Limits.MaxMemberNameLength) &&
+            !DisplayName.IsLongerThan(Limits.MaxMemberNameLength) &&
+            !Description.IsLongerThan(Limits.MaxDescriptionLength) &&
+            !Pronouns.IsLongerThan(Limits.MaxPronounsLength) &&
+            (Color == null || Regex.IsMatch(Color, "[0-9a-fA-F]{6}")) &&
+            // (Birthday == null || DateTimeFormats.DateExportFormat.Parse(Birthday).Success) &&
+
+            // Sanity checks
+            !AvatarUrl.IsLongerThan(1000) &&
+            (ProxyTags == null || ProxyTags.Count < 100);
+
+        public MemberPatch ToMemberPatch() => new MemberPatch
+        {
+            Name = Name,
+            DisplayName = DisplayName,
+            AvatarUrl = AvatarUrl,
+            Color = Color,
+            Birthday = Birthday,
+            Pronouns = Pronouns,
+            Description = Description,
+            ProxyTags = (Prefix != null || Suffix != null)
+                ? new[] {new ProxyTag(Prefix, Suffix)}
+                : (ProxyTags ?? new ProxyTag[] { }).Where(tag => !tag.IsEmpty).ToArray(),
+            KeepProxy = KeepProxy,
+            MessageCount = MessageCount,
+            AllowAutoproxy = AllowAutoproxy,
+            Visibility = MemberVisibility,
+            NamePrivacy = NamePrivacy,
+            DescriptionPrivacy = DescriptionPrivacy,
+            PronounPrivacy = PronounPrivacy,
+            BirthdayPrivacy = BirthdayPrivacy,
+            AvatarPrivacy = AvatarPrivacy,
+            MetadataPrivacy = MetadataPrivacy,
+        };
     }
 
     public static class PKMemberExt

--- a/PluralKit.Core/Models/Privacy/PrivacyLevel.cs
+++ b/PluralKit.Core/Models/Privacy/PrivacyLevel.cs
@@ -4,6 +4,7 @@ namespace PluralKit.Core
 {
     public enum PrivacyLevel
     {
+        // todo: string JSON for these
         Public = 1,
         Private = 2
     }


### PR DESCRIPTION
- import/export groups
- import/export privacy settings
- cleaned up BulkImporter code (now uses Patch.Apply instead of duplicating code)
- removed `DataFileMember` and added JSON properties to `PKMember` / `PKGroup` (so new member props are immediately added to the export file)

There's a couple things I'd like to add (like importing Tupperbox groups) but I'll work on that at some other time.

Also closes #277.