### PR TITLE
add temporary info message about increased message character limit

### DIFF
--- a/PluralKit.Bot/Proxy/ProxyService.cs
+++ b/PluralKit.Bot/Proxy/ProxyService.cs
@@ -54,6 +54,9 @@ namespace PluralKit.Bot
             if (!ShouldProxy(channel, message, ctx)) 
                 return false;
 
+            // this is hopefully temporary, so not putting it into a separate method
+            if (message.Content != null && message.Content.Length > 2000) throw new PKError("PluralKit cannot proxy messages over 2000 characters in length.");
+
             // Fetch members and try to match to a specific member
             await using var conn = await _db.Obtain();
 


### PR DESCRIPTION
Discord increased the character limit for Nitro users to 4000. ~~Predictably~~ Unfortunately, they didn't raise it for bots or webhooks, which means proxied messages will get cut off and logging will fail. This instead throws an error if the original message is above 2000 characters.