### PR TITLE
patch frontpercent

### DIFF
--- a/PluralKit.Bot/Commands/Groups.cs
+++ b/PluralKit.Bot/Commands/Groups.cs
@@ -523,8 +523,9 @@ namespace PluralKit.Bot
                 title.Append($"`{targetSystem.Hid}`");
 
             var ignoreNoFronters = ctx.MatchFlag("fo", "fronters-only");
+            var showFlat = ctx.MatchFlag("flat");
             var frontpercent = await _db.Execute(c => _repo.GetFrontBreakdown(c, targetSystem.Id, target.Id, rangeStart.Value.ToInstant(), now));
-            await ctx.Reply(embed: await _embeds.CreateFrontPercentEmbed(frontpercent, targetSystem, target, targetSystem.Zone, ctx.LookupContextFor(targetSystem), title.ToString(), ignoreNoFronters));
+            await ctx.Reply(embed: await _embeds.CreateFrontPercentEmbed(frontpercent, targetSystem, target, targetSystem.Zone, ctx.LookupContextFor(targetSystem), title.ToString(), ignoreNoFronters, showFlat));
         }
 
         private async Task<PKSystem> GetGroupSystem(Context ctx, PKGroup target, IPKConnection conn)

--- a/PluralKit.Bot/Commands/SystemFront.cs
+++ b/PluralKit.Bot/Commands/SystemFront.cs
@@ -135,8 +135,9 @@ namespace PluralKit.Bot
                 title.Append($"`{system.Hid}`");
 
             var ignoreNoFronters = ctx.MatchFlag("fo", "fronters-only");
+            var showFlat = ctx.MatchFlag("flat");
             var frontpercent = await _db.Execute(c => _repo.GetFrontBreakdown(c, system.Id, null, rangeStart.Value.ToInstant(), now));
-            await ctx.Reply(embed: await _embeds.CreateFrontPercentEmbed(frontpercent, system, null, system.Zone, ctx.LookupContextFor(system), title.ToString(), ignoreNoFronters));
+            await ctx.Reply(embed: await _embeds.CreateFrontPercentEmbed(frontpercent, system, null, system.Zone, ctx.LookupContextFor(system), title.ToString(), ignoreNoFronters, showFlat));
         }
     }
 }

--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -352,9 +352,11 @@ namespace PluralKit.Bot {
                 embedColor = DiscordUtils.Gray;
             }
           
-            var actualPeriod = breakdown.RangeEnd - breakdown.RangeStart;
-            // this is kinda messy?
-            var hasFrontersPeriod = Duration.FromTicks(breakdown.MemberSwitchDurations.Values.ToList().Sum(i => i.TotalTicks));
+            var period = breakdown.RangeEnd - breakdown.RangeStart;
+            var actualPeriod = period;
+
+            if (ignoreNoFronters)
+                period = period - breakdown.NoFronterDuration;
 
             var eb = new EmbedBuilder()
                 .Title(embedTitle)
@@ -371,7 +373,7 @@ namespace PluralKit.Bot {
             var membersOrdered = pairs.OrderByDescending(pair => pair.Value).Take(maxEntriesToDisplay).ToList();
             foreach (var pair in membersOrdered)
             {
-                var frac = pair.Value / (ignoreNoFronters ? hasFrontersPeriod : actualPeriod);
+                var frac = pair.Value / period;
                 eb.Field(new(pair.Key?.NameFor(ctx) ?? "*(no fronter)*", $"{frac*100:F0}% ({pair.Value.FormatDuration()})"));
             }
 

--- a/docs/content/tips-and-tricks.md
+++ b/docs/content/tips-and-tricks.md
@@ -73,4 +73,5 @@ These flags only work with the full member list (`pk;system list full`).
 |Command|Flag|Aliases|Description|
 |---|---|---|---|
 |pk;system frontpercent|-fronters-only|-fo|Shows the system's frontpercent without the "no fronter" entry|
+|pk;system frontpercent|-flat||Shows "flat" frontpercent - percentages add up to 100%|
 |pk;group \<group> frontpercent|-fronters-only|-fo|Shows a group's frontpercent without the "no fronter" entry|

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -462,6 +462,15 @@ To look at the per-member breakdown of the front over a given time period, use t
     pk;system qazws frontpercent 100d12h
 
 Note that in cases of switches with multiple members, each involved member will have the full length of the switch counted towards it. This means that the percentages may add up to over 100%.
+<br> It is possible to disable this with the `-flat` flag; percentages will then add up to 100%.
+
+::: tip
+If you use the `switch-out` function, the time when no-one was fronting will show up in front history as "no fronter". To disable this, use the `-fronters-only`, or `-fo` flag:
+
+```
+pk;system frontpercent -fronters-only
+```
+:::
 
 ## Member groups
 PluralKit allows you to categorize system members in different **groups**.


### PR DESCRIPTION
- fix incorrect timespan when ignoring "no fronters"
- add "flat" view (percentages add up to 100%)