### PR TITLE
Fix mentions in replies being cut off

### DIFF
--- a/PluralKit.Bot/Proxy/ProxyService.cs
+++ b/PluralKit.Bot/Proxy/ProxyService.cs
@@ -186,7 +186,7 @@ namespace PluralKit.Bot
                     }
 
                     var endsWithUrl = Regex.IsMatch(msg,
-                        @"(http|https)?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)$");
+                        @"(http|https)(:\/\/)?(www\.)?([-a-zA-Z0-9@:%._\+~#=]{1,256})?\.?([a-zA-Z0-9()]{1,6})?\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)$");
                     if (endsWithUrl)
                     {
                         var urlTail = repliedTo.Content.Substring(100).Split(" ")[0];

--- a/PluralKit.Bot/Proxy/ProxyService.cs
+++ b/PluralKit.Bot/Proxy/ProxyService.cs
@@ -177,13 +177,12 @@ namespace PluralKit.Bot
                 if (msg.Length > 100)
                 {
                     msg = repliedTo.Content.Substring(0, 100);
-                    var openedEmotesInTruncatedString = Regex.Matches(msg, @"<a?:").Count;
-                    var fullEmotesInTruncatedString = Regex.Matches(msg, @"<a?:\w+:\d+>").Count;
-                    if (openedEmotesInTruncatedString != fullEmotesInTruncatedString)
+                    var endsWithOpenMention = Regex.IsMatch(msg, @"<[at]?[@#:][!&]?(\w+:)?(\d+)?(:[tTdDfFR])?$");
+                    if (endsWithOpenMention)
                     {
-                        var emoteTail = repliedTo.Content.Substring(100).Split(">")[0];
-                        if (Regex.IsMatch(msg + emoteTail, @"<a?:\w+:\d+$"))
-                            msg += emoteTail + ">";
+                        var mentionTail = repliedTo.Content.Substring(100).Split(">")[0];
+                        if (Regex.IsMatch(msg + mentionTail, @"<[at]?[@#:][!&]?(\w+:)?\d+(:[tTdDfFR])?$"))
+                            msg += mentionTail + ">";
                     }
                     
                     var spoilersInOriginalString = Regex.Matches(repliedTo.Content, @"\|\|").Count;

--- a/PluralKit.Bot/Proxy/ProxyService.cs
+++ b/PluralKit.Bot/Proxy/ProxyService.cs
@@ -181,7 +181,7 @@ namespace PluralKit.Bot
                     if (endsWithOpenMention)
                     {
                         var mentionTail = repliedTo.Content.Substring(100).Split(">")[0];
-                        if (Regex.IsMatch(msg + mentionTail, @"<[at]?[@#:][!&]?(\w+:)?\d+(:[tTdDfFR])?$"))
+                        if (repliedTo.Content.Contains(msg + mentionTail + ">"))
                             msg += mentionTail + ">";
                     }
                     

--- a/PluralKit.Bot/Proxy/ProxyService.cs
+++ b/PluralKit.Bot/Proxy/ProxyService.cs
@@ -184,12 +184,21 @@ namespace PluralKit.Bot
                         if (repliedTo.Content.Contains(msg + mentionTail + ">"))
                             msg += mentionTail + ">";
                     }
+
+                    var endsWithUrl = Regex.IsMatch(msg,
+                        @"(http|https)?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)$");
+                    if (endsWithUrl)
+                    {
+                        var urlTail = repliedTo.Content.Substring(100).Split(" ")[0];
+                        msg += urlTail + " ";
+                    }
                     
                     var spoilersInOriginalString = Regex.Matches(repliedTo.Content, @"\|\|").Count;
                     var spoilersInTruncatedString = Regex.Matches(msg, @"\|\|").Count;
                     if (spoilersInTruncatedString % 2 == 1 && spoilersInOriginalString % 2 == 0)
                         msg += "||";
-                    msg += "…";
+                    if (msg != repliedTo.Content)
+                        msg += "…";
                 }
                 
                 content.Append($"**[Reply to:]({jumpLink})** ");

--- a/PluralKit.Bot/Proxy/ProxyService.cs
+++ b/PluralKit.Bot/Proxy/ProxyService.cs
@@ -177,6 +177,15 @@ namespace PluralKit.Bot
                 if (msg.Length > 100)
                 {
                     msg = repliedTo.Content.Substring(0, 100);
+                    var openedEmotesInTruncatedString = Regex.Matches(msg, @"<a?:").Count;
+                    var fullEmotesInTruncatedString = Regex.Matches(msg, @"<a?:\w+:\d+>").Count;
+                    if (openedEmotesInTruncatedString != fullEmotesInTruncatedString)
+                    {
+                        var emoteTail = repliedTo.Content.Substring(100).Split(">")[0];
+                        if (Regex.IsMatch(msg + emoteTail, @"<a?:\w+:\d+$"))
+                            msg += emoteTail + ">";
+                    }
+                    
                     var spoilersInOriginalString = Regex.Matches(repliedTo.Content, @"\|\|").Count;
                     var spoilersInTruncatedString = Regex.Matches(msg, @"\|\|").Count;
                     if (spoilersInTruncatedString % 2 == 1 && spoilersInOriginalString % 2 == 0)


### PR DESCRIPTION
This fixes discord mentions such as emotes or channel mentions being cut off in the middle due to the 100 character limit when replying via proxy. 

Before:
<img width="283" alt="before" src="https://user-images.githubusercontent.com/57954163/123419607-b4ddcc00-d5ba-11eb-9efa-2cbdfce9f9b2.png">

After:
<img width="193" alt="after" src="https://user-images.githubusercontent.com/57954163/123419600-b3140880-d5ba-11eb-9862-453043d57d03.png">