### PR TITLE
Avoid killing the gateway session when trying to resume

### DIFF
--- a/Myriad/Gateway/State/ShardStateManager.cs
+++ b/Myriad/Gateway/State/ShardStateManager.cs
@@ -163,7 +163,9 @@ namespace Myriad.Gateway
         private async Task HandleReconnect()
         {
             _logger.Information("Shard {ShardId}: Received Reconnect", _info.ShardId);
-            await DoReconnect(WebSocketCloseStatus.NormalClosure, TimeSpan.FromSeconds(1));
+            // close code 1000 kills the session, so can't reconnect
+            // we use 1005 (no error specified) instead
+            await DoReconnect(WebSocketCloseStatus.Empty, TimeSpan.FromSeconds(1));
         }
         
         private Task HandleReady(ReadyEvent ready)


### PR DESCRIPTION
Sending a 1000 close code invalidates the session, which means a shard will go offline for a few seconds when it needs to reconnect. Instead, we can use a 1005 close code (we could use any other non-1000 or 1001 code but 1005 seems more *correct*).