### PR TITLE
Use buttons for all yes/no prompts

### DIFF
--- a/Myriad/Rest/Types/Requests/MessageEditRequest.cs
+++ b/Myriad/Rest/Types/Requests/MessageEditRequest.cs
@@ -18,5 +18,8 @@ namespace Myriad.Rest.Types.Requests
         
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public Optional<AllowedMentions> AllowedMentions { get; init; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public Optional<MessageComponent[]?> Components { get; init; }
     }
 }

--- a/PluralKit.Bot/Commands/Groups.cs
+++ b/PluralKit.Bot/Commands/Groups.cs
@@ -51,7 +51,7 @@ namespace PluralKit.Bot
             var existingGroup = await _repo.GetGroupByName(conn, ctx.System.Id, groupName);
             if (existingGroup != null) {
                 var msg = $"{Emojis.Warn} You already have a group in your system with the name \"{existingGroup.Name}\" (with ID `{existingGroup.Hid}`). Do you want to create another group with the same name?";
-                if (!await ctx.PromptYesNo(msg))
+                if (!await ctx.PromptYesNo(msg, "Create"))
                     throw new PKError("Group creation cancelled.");
             }
             
@@ -81,7 +81,7 @@ namespace PluralKit.Bot
             var existingGroup = await _repo.GetGroupByName(conn, ctx.System.Id, newName);
             if (existingGroup != null && existingGroup.Id != target.Id) {
                 var msg = $"{Emojis.Warn} You already have a group in your system with the name \"{existingGroup.Name}\" (with ID `{existingGroup.Hid}`). Do you want to rename this member to that name too?";
-                if (!await ctx.PromptYesNo(msg))
+                if (!await ctx.PromptYesNo(msg, "Rename"))
                     throw new PKError("Group creation cancelled.");
             }
 

--- a/PluralKit.Bot/Commands/ImportExport.cs
+++ b/PluralKit.Bot/Commands/ImportExport.cs
@@ -73,7 +73,7 @@ namespace PluralKit.Bot
                     if (data.LinkedAccounts != null && !data.LinkedAccounts.Contains(ctx.Author.Id))
                     {
                         var msg = $"{Emojis.Warn} You seem to importing a system profile belonging to another account. Are you sure you want to proceed?";
-                        if (!await ctx.PromptYesNo(msg)) throw Errors.ImportCancelled;
+                        if (!await ctx.PromptYesNo(msg, "Import")) throw Errors.ImportCancelled;
                     }
 
                     // If passed system is null, it'll create a new one
@@ -120,7 +120,7 @@ namespace PluralKit.Bot
                     issueStr += "\n- PluralKit does not support per-member system tags. Since you had multiple members with distinct tags, those tags will be applied to the members' *display names*/nicknames instead.";
 
                 var msg = $"{issueStr}\n\nDo you want to proceed with the import?";
-                if (!await ctx.PromptYesNo(msg))
+                if (!await ctx.PromptYesNo(msg, "Import"))
                     throw Errors.ImportCancelled;
             }
 

--- a/PluralKit.Bot/Commands/ImportExport.cs
+++ b/PluralKit.Bot/Commands/ImportExport.cs
@@ -120,7 +120,7 @@ namespace PluralKit.Bot
                     issueStr += "\n- PluralKit does not support per-member system tags. Since you had multiple members with distinct tags, those tags will be applied to the members' *display names*/nicknames instead.";
 
                 var msg = $"{issueStr}\n\nDo you want to proceed with the import?";
-                if (!await ctx.PromptYesNo(msg, "Import"))
+                if (!await ctx.PromptYesNo(msg, "Proceed"))
                     throw Errors.ImportCancelled;
             }
 

--- a/PluralKit.Bot/Commands/Member.cs
+++ b/PluralKit.Bot/Commands/Member.cs
@@ -41,7 +41,7 @@ namespace PluralKit.Bot
             var existingMember = await _db.Execute(c => _repo.GetMemberByName(c, ctx.System.Id, memberName));
             if (existingMember != null) {
                 var msg = $"{Emojis.Warn} You already have a member in your system with the name \"{existingMember.NameFor(ctx)}\" (with ID `{existingMember.Hid}`). Do you want to create another member with the same name?";
-                if (!await ctx.PromptYesNo(msg)) throw new PKError("Member creation cancelled.");
+                if (!await ctx.PromptYesNo(msg, "Create")) throw new PKError("Member creation cancelled.");
             }
 
             await using var conn = await _db.Obtain();

--- a/PluralKit.Bot/Commands/MemberEdit.cs
+++ b/PluralKit.Bot/Commands/MemberEdit.cs
@@ -35,7 +35,7 @@ namespace PluralKit.Bot
             if (existingMember != null && existingMember.Id != target.Id) 
             {
                 var msg = $"{Emojis.Warn} You already have a member in your system with the name \"{existingMember.NameFor(ctx)}\" (`{existingMember.Hid}`). Do you want to rename this member to that name too?";
-                if (!await ctx.PromptYesNo(msg)) throw new PKError("Member renaming cancelled.");
+                if (!await ctx.PromptYesNo(msg, "Rename")) throw new PKError("Member renaming cancelled.");
             }
 
             // Rename the member

--- a/PluralKit.Bot/Commands/MemberProxy.cs
+++ b/PluralKit.Bot/Commands/MemberProxy.cs
@@ -42,7 +42,7 @@ namespace PluralKit.Bot
 
                 var conflictList = conflicts.Select(m => $"- **{m.NameFor(ctx)}**");
                 var msg = $"{Emojis.Warn} The following members have conflicting proxy tags:\n{string.Join('\n', conflictList)}\nDo you want to proceed anyway?";
-                return await ctx.PromptYesNo(msg);
+                return await ctx.PromptYesNo(msg, "Proceed");
             }
             
             // "Sub"command: clear flag
@@ -52,7 +52,7 @@ namespace PluralKit.Bot
                 if (target.ProxyTags.Count > 1)
                 {
                     var msg = $"{Emojis.Warn} You already have multiple proxy tags set: {target.ProxyTagsString()}\nDo you want to clear them all?";
-                    if (!await ctx.PromptYesNo(msg))
+                    if (!await ctx.PromptYesNo(msg, "Clear"))
                         throw Errors.GenericCancelled();
                 }
                 
@@ -117,7 +117,7 @@ namespace PluralKit.Bot
                 if (target.ProxyTags.Count > 1)
                 {
                     var msg = $"This member already has more than one proxy tag set: {target.ProxyTagsString()}\nDo you want to replace them?";
-                    if (!await ctx.PromptYesNo(msg))
+                    if (!await ctx.PromptYesNo(msg, "Replace"))
                         throw Errors.GenericCancelled();
                 }
                 

--- a/PluralKit.Bot/Commands/SystemEdit.cs
+++ b/PluralKit.Bot/Commands/SystemEdit.cs
@@ -294,7 +294,7 @@ namespace PluralKit.Bot
 
             var currentTime = SystemClock.Instance.GetCurrentInstant().InZone(zone);
             var msg = $"This will change the system time zone to **{zone.Id}**. The current time is **{currentTime.FormatZoned()}**. Is this correct?";
-            if (!await ctx.PromptYesNo(msg)) throw Errors.TimezoneChangeCancelled;
+            if (!await ctx.PromptYesNo(msg, "Change Timezone")) throw Errors.TimezoneChangeCancelled;
             
             var patch = new SystemPatch {UiTz = zone.Id};
             await _db.Execute(conn => _repo.UpdateSystem(conn, ctx.System.Id, patch));

--- a/PluralKit.Bot/Commands/SystemLink.cs
+++ b/PluralKit.Bot/Commands/SystemLink.cs
@@ -34,9 +34,8 @@ namespace PluralKit.Bot
             if (existingAccount != null)
                 throw Errors.AccountInOtherSystem(existingAccount); 
 
-            var msg = $"{account.Mention()}, please confirm the link by clicking the {Emojis.Success} reaction on this message.";
-            var mentions = new AllowedMentions {Users = new[] {account.Id}};
-            if (!await ctx.PromptYesNo(msg, user: account, mentions: mentions, matchFlag: false)) throw Errors.MemberLinkCancelled;
+            var msg = $"{account.Mention()}, please confirm the link.";
+            if (!await ctx.PromptYesNo(msg, "Confirm", user: account, matchFlag: false)) throw Errors.MemberLinkCancelled;
             await _repo.AddAccount(conn, ctx.System.Id, account.Id);
             await ctx.Reply($"{Emojis.Success} Account linked to system.");
         }
@@ -58,7 +57,7 @@ namespace PluralKit.Bot
             if (accountIds.Count == 1) throw Errors.UnlinkingLastAccount;
             
             var msg = $"Are you sure you want to unlink <@{id}> from your system?";
-            if (!await ctx.PromptYesNo(msg)) throw Errors.MemberUnlinkCancelled;
+            if (!await ctx.PromptYesNo(msg, "Unlink")) throw Errors.MemberUnlinkCancelled;
 
             await _repo.RemoveAccount(conn, ctx.System.Id, id);
             await ctx.Reply($"{Emojis.Success} Account unlinked.");


### PR DESCRIPTION
This moves PromptYesNo to buttons instead of reactions. I felt it was important to still have text-based responses so I added that to the `YesNoPrompt` interactive. (The code for that could be a bit tidier, tbh, but I'm not sure exactly *how* it should be, so I left it.)