### PR TITLE
Added crosslink to the Pluralkit support list

### DIFF
--- a/docs/content/staff/compatibility.md
+++ b/docs/content/staff/compatibility.md
@@ -7,6 +7,7 @@ Some logger bots have offical PluralKit support, and properly handle excluding p
 
 - [**Gabby Gums**](https://github.com/amadea-system/GabbyGums)
 - [**Catalogger**](https://catalogger.starshines.xyz/docs)
+- [**Crosslink**](https://crss.link)
 
 If your server uses an in-house bot for logging, you can use [the API](../api-documentation.md) to implement support yourself.
 


### PR DESCRIPTION
Support includes log cleanup and utilising the Pluralkit API to tie proxy messages back to the original poster, supplying additional data in deletion logs and applying punishments to the original author. See image below:
https://cdn.discordapp.com/attachments/775164748630720514/831210798638039110/unknown.png