### PR TITLE
Fix Discord merging webhook messages with same username

### DIFF
--- a/Myriad/Rest/DiscordApiClient.cs
+++ b/Myriad/Rest/DiscordApiClient.cs
@@ -29,6 +29,9 @@ namespace Myriad.Rest
         public Task<Channel?> GetChannel(ulong channelId) =>
             _client.Get<Channel>($"/channels/{channelId}", ("GetChannel", channelId));
 
+        public Task<Message[]?> GetChannelMessages(ulong channelId, int? limit = 50) =>
+            _client.Get<Message[]>($"/channels/{channelId}/messages?limit={limit}", ("GetChannelMessages", channelId));
+
         public Task<Message?> GetMessage(ulong channelId, ulong messageId) =>
             _client.Get<Message>($"/channels/{channelId}/messages/{messageId}", ("GetMessage", channelId));
 

--- a/PluralKit.Bot/Proxy/ProxyService.cs
+++ b/PluralKit.Bot/Proxy/ProxyService.cs
@@ -33,10 +33,11 @@ namespace PluralKit.Bot
         private readonly ProxyMatcher _matcher;
         private readonly IMetrics _metrics;
         private readonly IDiscordCache _cache;
+        private readonly LastMessageCacheService _lastMessage;
         private readonly DiscordApiClient _rest;
 
-        public ProxyService(LogChannelService logChannel, ILogger logger,
-                            WebhookExecutorService webhookExecutor, IDatabase db, ProxyMatcher matcher, IMetrics metrics, ModelRepository repo, IDiscordCache cache, DiscordApiClient rest)
+        public ProxyService(LogChannelService logChannel, ILogger logger, WebhookExecutorService webhookExecutor, IDatabase db,
+            ProxyMatcher matcher, IMetrics metrics, ModelRepository repo, IDiscordCache cache, DiscordApiClient rest, LastMessageCacheService lastMessage)
         {
             _logChannel = logChannel;
             _webhookExecutor = webhookExecutor;
@@ -45,6 +46,7 @@ namespace PluralKit.Bot
             _metrics = metrics;
             _repo = repo;
             _cache = cache;
+            _lastMessage = lastMessage;
             _rest = rest;
             _logger = logger.ForContext<ProxyService>();
         }
@@ -142,7 +144,7 @@ namespace PluralKit.Bot
                 GuildId = trigger.GuildId!.Value,
                 ChannelId = rootChannel.Id,
                 ThreadId = threadId,
-                Name = match.Member.ProxyName(ctx),
+                Name = await FixSameName(messageChannel.Id, ctx, match.Member),
                 AvatarUrl = AvatarUtils.TryRewriteCdnUrl(match.Member.ProxyAvatar(ctx)),
                 Content = content,
                 Attachments = trigger.Attachments,
@@ -229,6 +231,56 @@ namespace PluralKit.Bot
                 Color = match.Member.Color?.ToDiscordColor(),
             };
         }
+
+        private async Task<string> FixSameName(ulong channel_id, MessageContext ctx, ProxyMember member)
+        {
+            var proxyName = member.ProxyName(ctx);
+
+            Message? lastMessage = null;
+
+            var lastMessageId = _lastMessage.GetLastMessage(channel_id)?.Previous;
+            if (lastMessageId == null)
+            {
+                _logger.Debug("Last message cache for channel {ulong} is out of date (or channel has no messages), fetching from REST.", channel_id);
+                var messages = await _rest.GetChannelMessages(channel_id, limit: 2);
+
+                // the last message is the trigger message, so (try to) get the one before that
+                // might break if we're too slow to proxy and someone sends a message in the meantime, but shouldn't happen?
+                if (messages.Length > 1)
+                    lastMessage = messages[1];
+            }
+            else
+                lastMessage = await _rest.GetMessage(channel_id, lastMessageId.Value);
+
+            if (lastMessage == null)
+                // we don't have enough information to figure out if we need to fix the name, so bail here.
+                return proxyName;
+
+            await using var conn = await _db.Obtain();
+            var message = await _repo.GetMessage(conn, lastMessage.Id);
+
+            if (lastMessage.Author.Username == proxyName)
+            {
+                // last message wasn't proxied by us, but somehow has the same name
+                // it's probably from a different webhook (Tupperbox?) but let's fix it anyway!
+                if (message == null)
+                    return FixSameNameInner(proxyName);
+
+                // last message was proxied by a different member
+                if (message.Member.Id != member.Id)
+                    return FixSameNameInner(proxyName);
+            }
+
+            // if we fixed the name last message and it's the same member proxying, we want to fix it again
+            if (lastMessage.Author.Username == FixSameNameInner(proxyName) && message?.Member.Id == member.Id)
+                return FixSameNameInner(proxyName);
+
+            // No issues found, current proxy name is fine.
+            return proxyName;
+        }
+
+        private string FixSameNameInner(string name)
+            => $"{name}\u17b5";
 
         private async Task HandleProxyExecutedActions(Shard shard, IPKConnection conn, MessageContext ctx,
                                                       Message triggerMessage, Message proxyMessage,

--- a/PluralKit.Bot/Services/LastMessageCacheService.cs
+++ b/PluralKit.Bot/Services/LastMessageCacheService.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 
 using Myriad.Types;
 
@@ -13,14 +14,58 @@ namespace PluralKit.Bot
 
         public void AddMessage(Message msg)
         {
-            _cache[msg.ChannelId] = new CachedMessage(msg.Id, msg.ReferencedMessage.Value?.Id);
+            var previous = GetLastMessage(msg.ChannelId);
+            _cache[msg.ChannelId] = new CachedMessage(msg.Id, msg.ReferencedMessage.Value?.Id, previous?.Id);
         }
 
         public CachedMessage? GetLastMessage(ulong channel)
         {
             return _cache.TryGetValue(channel, out var message) ? message : null;
         }
+
+        public void HandleMessageDeletion(ulong channel, ulong message)
+        {
+            var storedMessage = GetLastMessage(channel);
+            if (storedMessage == null)
+                return;
+
+            if (message == storedMessage.Id)
+                if (storedMessage.Previous != null)
+                    _cache[channel] = new CachedMessage(storedMessage.Previous.Value, null, null);
+                else
+                    _cache.Remove(channel);
+            else if (message == storedMessage.Previous)
+                _cache[channel] = new CachedMessage(storedMessage.Id, storedMessage.ReferencedMessage, null);
+        }
+
+        public void HandleMessageDeletion(ulong channel, List<ulong> messages)
+        {
+            var storedMessage = GetLastMessage(channel);
+            if (storedMessage == null)
+                return;
+
+            if (!(messages.Contains(storedMessage.Id) || (storedMessage.Previous != null && messages.Contains(storedMessage.Previous.Value))))
+                // none of the deleted messages are relevant to the cache
+                return;
+
+            ulong? newLastMessage = null;
+
+            if (messages.Contains(storedMessage.Id))
+                newLastMessage = storedMessage.Previous;
+
+            if (storedMessage.Previous != null && messages.Contains(storedMessage.Previous.Value))
+                if (newLastMessage == storedMessage.Previous)
+                    newLastMessage = null;
+                else
+                {
+                    _cache[channel] = new CachedMessage(storedMessage.Id, storedMessage.ReferencedMessage, null);
+                    return;
+                }
+
+            if (newLastMessage == null)
+                _cache.Remove(channel);
+        }
     }
 
-    public record CachedMessage(ulong Id, ulong? ReferencedMessage);
+    public record CachedMessage(ulong Id, ulong? ReferencedMessage, ulong? Previous);
 }


### PR DESCRIPTION
This works, but I'm not sure if there's any issues that might pop up in channels with lots of activity.

The actual checking if it needs to fix the name is simple enough; finding the last proxied message is a larger issue:
- a message can be deleted, but still be in the LastMessageCache. So, I added a method that listens to MessageDelete event and cleans up the cache.
- the LastMessageCache can be missing or out of date (too many messages were deleted, or the bot was restarted). So, we fetch the last message from Discord.