### PR TITLE
Feature proxy permcheck

### DIFF
--- a/PluralKit.Bot/Commands/CommandTree.cs
+++ b/PluralKit.Bot/Commands/CommandTree.cs
@@ -80,6 +80,7 @@ namespace PluralKit.Bot
         public static Command Explain = new Command("explain", "explain", "Explains the basics of systems and proxying");
         public static Command Message = new Command("message", "message <id|link> [delete|author]", "Looks up a proxied message");
         public static Command MessageEdit = new Command("edit", "edit [link] <text>", "Edit a previously proxied message");
+        public static Command ProxyCheck = new Command("proxycheck", "proxycheck [link]", "Check why a message has not been proxied");
         public static Command LogChannel = new Command("log channel", "log channel <channel>", "Designates a channel to post proxied messages to");
         public static Command LogChannelClear = new Command("log channel", "log channel -clear", "Clears the currently set log channel");
         public static Command LogEnable = new Command("log enable", "log enable all|<channel> [channel 2] [channel 3...]", "Enables message logging in certain channels");
@@ -164,6 +165,8 @@ namespace PluralKit.Bot
                 return ctx.Execute<Misc>(Message, m => m.GetMessage(ctx));
             if (ctx.Match("edit", "e"))
                 return ctx.Execute<MessageEdit>(MessageEdit, m => m.EditMessage(ctx));
+            if (ctx.Match("proxycheck"))
+                return ctx.Execute<Misc>(ProxyCheck, m => m.MessageProxyCheck(ctx));
             if (ctx.Match("log"))
                 if (ctx.Match("channel"))
                     return ctx.Execute<ServerConfig>(LogChannel, m => m.SetLogChannel(ctx));

--- a/PluralKit.Bot/Commands/CommandTree.cs
+++ b/PluralKit.Bot/Commands/CommandTree.cs
@@ -80,7 +80,7 @@ namespace PluralKit.Bot
         public static Command Explain = new Command("explain", "explain", "Explains the basics of systems and proxying");
         public static Command Message = new Command("message", "message <id|link> [delete|author]", "Looks up a proxied message");
         public static Command MessageEdit = new Command("edit", "edit [link] <text>", "Edit a previously proxied message");
-        public static Command ProxyCheck = new Command("proxycheck", "proxycheck [link]", "Check why a message has not been proxied");
+        public static Command ProxyCheck = new Command("proxycheck", "proxycheck [link]", "Checks why your message has not been proxied");
         public static Command LogChannel = new Command("log channel", "log channel <channel>", "Designates a channel to post proxied messages to");
         public static Command LogChannelClear = new Command("log channel", "log channel -clear", "Clears the currently set log channel");
         public static Command LogEnable = new Command("log enable", "log enable all|<channel> [channel 2] [channel 3...]", "Enables message logging in certain channels");

--- a/PluralKit.Bot/Commands/Misc.cs
+++ b/PluralKit.Bot/Commands/Misc.cs
@@ -17,6 +17,7 @@ using Myriad.Cache;
 using Myriad.Extensions;
 using Myriad.Gateway;
 using Myriad.Rest;
+using Myriad.Rest.Exceptions;
 using Myriad.Rest.Types.Requests;
 using Myriad.Types;
 
@@ -278,14 +279,12 @@ namespace PluralKit.Bot {
             }
             
             // get the message info
-            // is the try/catch block a good idea? otherwise we'd get internal errors when we can't fetch the message
-            // which is good when pluralkit just can't view the message, but not sure about stuff like network errors
             var msg = ctx.Message;
             try 
             {
                 msg = await _rest.GetMessage(channelId, messageId);
             }
-            catch
+            catch (ForbiddenException)
             {
                 throw new PKError("Unable to get the message provided.");
             }

--- a/PluralKit.Bot/Handlers/MessageCreated.cs
+++ b/PluralKit.Bot/Handlers/MessageCreated.cs
@@ -162,6 +162,10 @@ namespace PluralKit.Bot
                         new MessageRequest {Content = $"{Emojis.Error} {e.Message}"});
                 }
             }
+            // Catch any failed proxy checks so they get ignored in the global error handler
+            catch (ProxyService.ProxyChecksFailedException)
+            {
+            }
 
             return false;
         }

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -118,6 +118,7 @@ Some arguments indicate the use of specific Discord features. These include:
 ## Utility
 - `pk;random [-group]` - Shows the info card of a randomly selected member [or group] in your system.
 - `pk;message <message id|message link|reply>` - Looks up information about a proxied message by its message ID or link.
+- `pk;proxycheck <message link|reply>` - Checks why your message has not been proxied.
 - `pk;invite` - Sends the bot invite link for PluralKit.
 - `pk;import` - Imports a data file from PluralKit or Tupperbox.
 - `pk;export` - Exports a data file containing your system information.


### PR DESCRIPTION
This PR adds a `pk;proxycheck` command, which goes through all the checks for a non-proxied message and sends a message detailing why a message hasn't been proxied.

It works by changing how the proxy checks work, throwing a ProxyChecksFailedException instead of silently failing. This exception gets ignored by the global exception handler. `pk;proxycheck` fetches the message using a reply or a message link, then runs it through the same proxy checks, and replies with the ProxyChecksFailedException message.