### PR TITLE
Add color to system model for API

### DIFF
--- a/PluralKit.Core/Models/PKSystem.cs
+++ b/PluralKit.Core/Models/PKSystem.cs
@@ -72,6 +72,7 @@ namespace PluralKit.Core
             o.Add("tag", system.Tag);
             o.Add("avatar_url", system.AvatarUrl.TryGetCleanCdnUrl());
             o.Add("banner", system.DescriptionPrivacy.Get(ctx, system.BannerImage).TryGetCleanCdnUrl());
+            o.Add("color", system.Color);
             o.Add("created", system.Created.FormatExport());
             // todo: change this to "timezone"
             o.Add("tz", system.UiTz);

--- a/PluralKit.Core/Models/Patch/SystemPatch.cs
+++ b/PluralKit.Core/Models/Patch/SystemPatch.cs
@@ -77,6 +77,7 @@ namespace PluralKit.Core
             if (o.ContainsKey("tag")) patch.Tag = o.Value<string>("tag").NullIfEmpty();
             if (o.ContainsKey("avatar_url")) patch.AvatarUrl = o.Value<string>("avatar_url").NullIfEmpty();
             if (o.ContainsKey("banner")) patch.BannerImage = o.Value<string>("banner").NullIfEmpty();
+            if (o.ContainsKey("color")) patch.Color = o.Value<string>("color").NullIfEmpty();
             if (o.ContainsKey("timezone")) patch.UiTz = o.Value<string>("tz") ?? "UTC";
 
             // legacy: APIv1 uses "tz" instead of "timezone"

--- a/docs/content/api-documentation.md
+++ b/docs/content/api-documentation.md
@@ -55,6 +55,7 @@ A `?` after the column type indicates a nullable parameter (value can be cleared
 | name                  | string   | Yes        | 100-character limit.                                                                      |
 | description           | string?  | Yes        | 1000-character limit.                                                                     |
 | tag                   | string?  | Yes        |                                                                                           |
+| color                 | string?  | Yes        | 6-char hex (eg. `ff7000`), sans `#`.                                                      |
 | avatar_url            | url?     | Yes        | Not validated server-side.                                                                |
 | banner                | url?     | Yes        | Not validated server-side.                                                                |
 | tz                    | string?  | Yes        | Tzdb identifier. Patching with `null` will store `"UTC"`.                                 |


### PR DESCRIPTION
Adds the `color` property to the patch from JSON function, ToJson function, and the API documentation for the system model