### PR TITLE
Fix single asterisk note under "create switch"

### DIFF
--- a/docs/content/api/endpoints.md
+++ b/docs/content/api/endpoints.md
@@ -234,7 +234,7 @@ JSON Body Parameters
 |?timestamp|datetime*|when the switch started|
 |members|list of strings**|members present in the switch (or empty list for switch-out)|
 
-* Defaults to "now" when missing.
+\* Defaults to "now" when missing.
 
 ** Can be short IDs or UUIDs.
 


### PR DESCRIPTION
Just escaping it so it doesn't become a bullet point