### PR TITLE
fix: display correct color when looking up other systems' groups

### DIFF
--- a/PluralKit.Bot/Commands/Groups.cs
+++ b/PluralKit.Bot/Commands/Groups.cs
@@ -460,7 +460,7 @@ public class Groups
         }
 
         var title = system.Name != null ? $"Groups of {system.Name} (`{system.Hid}`)" : $"Groups of `{system.Hid}`";
-        await ctx.Paginate(groups.ToAsyncEnumerable(), groups.Count, 25, title, ctx.System.Color, Renderer);
+        await ctx.Paginate(groups.ToAsyncEnumerable(), groups.Count, 25, title, system.Color, Renderer);
 
         Task Renderer(EmbedBuilder eb, IEnumerable<ListedGroup> page)
         {


### PR DESCRIPTION
currently your own system's color gets displayed when looking up another system's groups, this PR fixes that.