### PR TITLE
feat: make cancelled commands reply to trigger

### DIFF
--- a/PluralKit.Bot/CommandSystem/Context/Context.cs
+++ b/PluralKit.Bot/CommandSystem/Context/Context.cs
@@ -77,7 +77,7 @@ public class Context
     internal readonly IDatabase Database;
     internal readonly ModelRepository Repository;
 
-    public async Task<Message> Reply(string text = null, Embed embed = null, AllowedMentions? mentions = null)
+    public async Task<Message> Reply(string text = null, Embed embed = null, AllowedMentions? mentions = null, bool referenceCommand = false)
     {
         var botPerms = await BotPermissions;
 
@@ -92,6 +92,7 @@ public class Context
         {
             Content = text,
             Embeds = embed != null ? new[] { embed } : null,
+            MessageReference = referenceCommand ? new Message.Reference(Message.GuildId, Message.ChannelId, Message.Id) : null,
             // Default to an empty allowed mentions object instead of null (which means no mentions allowed)
             AllowedMentions = mentions ?? new AllowedMentions()
         });
@@ -121,6 +122,10 @@ public class Context
         {
             await Reply($"{Emojis.Error} {e.Message}\n**Command usage:**\n> pk;{commandDef?.Usage}");
         }
+        catch (PKCancelError e)
+        {
+            await Reply($"{Emojis.Error} {e.Message}", null, null, true);
+        }
         catch (PKError e)
         {
             await Reply($"{Emojis.Error} {e.Message}");
@@ -128,7 +133,7 @@ public class Context
         catch (TimeoutException)
         {
             // Got a complaint the old error was a bit too patronizing. Hopefully this is better?
-            await Reply($"{Emojis.Error} Operation timed out, sorry. Try again, perhaps?");
+            await Reply($"{Emojis.Error} Operation timed out, sorry. Try again, perhaps?", null, null, true);
         }
 
         if (deprecated && commandDef != null)

--- a/PluralKit.Bot/CommandSystem/Context/Context.cs
+++ b/PluralKit.Bot/CommandSystem/Context/Context.cs
@@ -77,7 +77,7 @@ public class Context
     internal readonly IDatabase Database;
     internal readonly ModelRepository Repository;
 
-    public async Task<Message> Reply(string text = null, Embed embed = null, AllowedMentions? mentions = null, bool referenceCommand = false)
+    public async Task<Message> Reply(string text = null, Embed embed = null, AllowedMentions? mentions = null, Message.Reference replyTo = null)
     {
         var botPerms = await BotPermissions;
 
@@ -92,7 +92,7 @@ public class Context
         {
             Content = text,
             Embeds = embed != null ? new[] { embed } : null,
-            MessageReference = referenceCommand ? new Message.Reference(Message.GuildId, Message.ChannelId, Message.Id) : null,
+            MessageReference = replyTo != null ? replyTo : null,
             // Default to an empty allowed mentions object instead of null (which means no mentions allowed)
             AllowedMentions = mentions ?? new AllowedMentions()
         });
@@ -124,7 +124,7 @@ public class Context
         }
         catch (PKCancelError e)
         {
-            await Reply($"{Emojis.Error} {e.Message}", null, null, true);
+            await Reply($"{Emojis.Error} {e.Message}", replyTo: new Message.Reference(Message.GuildId, Message.ChannelId, Message.Id));
         }
         catch (PKError e)
         {
@@ -133,7 +133,7 @@ public class Context
         catch (TimeoutException)
         {
             // Got a complaint the old error was a bit too patronizing. Hopefully this is better?
-            await Reply($"{Emojis.Error} Operation timed out, sorry. Try again, perhaps?", null, null, true);
+            await Reply($"{Emojis.Error} Operation timed out, sorry. Try again, perhaps?", replyTo: new Message.Reference(Message.GuildId, Message.ChannelId, Message.Id));
         }
 
         if (deprecated && commandDef != null)

--- a/PluralKit.Bot/Errors.cs
+++ b/PluralKit.Bot/Errors.cs
@@ -25,6 +25,11 @@ public class PKSyntaxError: PKError
     public PKSyntaxError(string message) : base(message) { }
 }
 
+public class PKCancelError : PKError
+{
+    public PKCancelError(string message) : base(message) { }
+}
+
 public static class Errors
 {
     // TODO: is returning constructed errors and throwing them at call site a good idea, or should these be methods that insta-throw instead?
@@ -51,7 +56,7 @@ public static class Errors
     public static PKError ProxyMultipleText =>
         new PKSyntaxError("Example proxy message must contain the string 'text' exactly once.");
 
-    public static PKError MemberDeleteCancelled => new($"Member deletion cancelled. Stay safe! {Emojis.ThumbsUp}");
+    public static PKCancelError MemberDeleteCancelled => new($"Member deletion cancelled. Stay safe! {Emojis.ThumbsUp}");
 
     public static PKError AvatarInvalid =>
         new("Could not read image file - perhaps it's corrupted or the wrong format. Try a different image.");
@@ -64,17 +69,17 @@ public static class Errors
     public static PKError UnlinkingLastAccount => new(
         "Since this is the only account linked to this system, you cannot unlink it (as that would leave your system account-less). If you would like to delete your system, use `pk;system delete`.");
 
-    public static PKError MemberLinkCancelled => new("Member link cancelled.");
-    public static PKError MemberUnlinkCancelled => new("Member unlink cancelled.");
+    public static PKCancelError MemberLinkCancelled => new("Member link cancelled.");
+    public static PKCancelError MemberUnlinkCancelled => new("Member unlink cancelled.");
 
     public static PKError DuplicateSwitchMembers => new("Duplicate members in member list.");
     public static PKError SwitchMemberNotInSystem => new("One or more switch members aren't in your own system.");
     public static PKError SwitchTimeInFuture => new("Can't move switch to a time in the future.");
     public static PKError NoRegisteredSwitches => new("There are no registered switches for this system.");
-    public static PKError SwitchMoveCancelled => new("Switch move cancelled.");
-    public static PKError SwitchEditCancelled => new("Switch edit cancelled.");
-    public static PKError SwitchDeleteCancelled => new("Switch deletion cancelled.");
-    public static PKError TimezoneChangeCancelled => new("Time zone change cancelled.");
+    public static PKCancelError SwitchMoveCancelled => new("Switch move cancelled.");
+    public static PKCancelError SwitchEditCancelled => new("Switch edit cancelled.");
+    public static PKCancelError SwitchDeleteCancelled => new("Switch deletion cancelled.");
+    public static PKCancelError TimezoneChangeCancelled => new("Time zone change cancelled.");
 
     public static PKError NoImportFilePassed =>
         new(
@@ -84,7 +89,7 @@ public static class Errors
         new(
             "Imported data file invalid. Make sure this is a .json file directly exported from PluralKit or Tupperbox.");
 
-    public static PKError ImportCancelled => new("Import cancelled.");
+    public static PKCancelError ImportCancelled => new("Import cancelled.");
 
     public static PKError FrontPercentTimeInFuture =>
         new("Cannot get the front percent between now and a time in the future.");
@@ -176,7 +181,7 @@ public static class Errors
     public static PKError EmptyProxyTags(PKMember member, Context ctx) => new(
         $"The example proxy `text` is equivalent to having no proxy tags at all, since there are no symbols or brackets on either end. If you'd like to clear your proxy tags, use `pk;member {member.Reference(ctx)} proxy clear`.");
 
-    public static PKError GenericCancelled() => new("Operation cancelled.");
+    public static PKCancelError GenericCancelled() => new("Operation cancelled.");
 
     public static PKError AttachmentTooLarge(int mb) => new(
         $"PluralKit cannot proxy attachments over {mb} megabytes in this server (as webhooks aren't considered as having Discord Nitro) :(");

--- a/PluralKit.Bot/Utils/ContextUtils.cs
+++ b/PluralKit.Bot/Utils/ContextUtils.cs
@@ -120,7 +120,8 @@ public static class ContextUtils
                 while (true)
                 {
                     var reaction = await ctx.AwaitReaction(msg, ctx.Author, timeout: Duration.FromMinutes(5));
-
+                    Message? promptMessage = null;
+                    
                     // Increment/decrement page counter based on which reaction was clicked
                     if (reaction.Emoji.Name == "\u23EA") currentPage = 0; // <<
                     else if (reaction.Emoji.Name == "\u2B05") currentPage = (currentPage - 1) % pageCount; // <
@@ -138,11 +139,10 @@ public static class ContextUtils
                     else if (reaction.Emoji.Name == "\u0038\uFE0F\u20E3" && pageCount >= 7) currentPage = 7;
                     else if (reaction.Emoji.Name == "\u0039\uFE0F\u20E3" && pageCount >= 8) currentPage = 8;
                     else if (reaction.Emoji.Name == "\U0001f51f" && pageCount >= 9) currentPage = 9;
-
                     else if (reaction.Emoji.Name == "\uD83D\uDD22")
                         try
                         {
-                            await ctx.Reply("What page would you like to go to?");
+                            promptMessage = await ctx.Reply("What page would you like to go to?");
                             var repliedNum = await PromptPageNumber();
                             if (repliedNum < 1)
                             {
@@ -161,7 +161,14 @@ public static class ContextUtils
                         }
                         catch (TimeoutException)
                         {
-                            await ctx.Reply($"{Emojis.Error} Operation timed out, sorry. Try again, perhaps?", null, null, true);
+                            if (promptMessage != null) 
+                            {
+                                await ctx.Reply($"{Emojis.Error} Operation timed out, sorry. Try again, perhaps?", replyTo: new Message.Reference(promptMessage.GuildId, promptMessage.ChannelId, promptMessage.Id));
+                            }
+                            else
+                            {
+                                await ctx.Reply($"{Emojis.Error} Operation timed out, sorry. Try again, perhaps?");
+                            }
                             continue;
                         }
 

--- a/PluralKit.Bot/Utils/ContextUtils.cs
+++ b/PluralKit.Bot/Utils/ContextUtils.cs
@@ -161,7 +161,7 @@ public static class ContextUtils
                         }
                         catch (TimeoutException)
                         {
-                            await ctx.Reply($"{Emojis.Error} Operation timed out, sorry. Try again, perhaps?");
+                            await ctx.Reply($"{Emojis.Error} Operation timed out, sorry. Try again, perhaps?", null, null, true);
                             continue;
                         }
 


### PR DESCRIPTION
makes all "operation cancelled" errors and variants thereof reply to it's trigger message. this happens both with prompts being timed out and being cancelled manually.