### PR TITLE
Add some frequently-requested command aliases

### DIFF
--- a/PluralKit.Bot/CommandMeta/CommandTree.cs
+++ b/PluralKit.Bot/CommandMeta/CommandTree.cs
@@ -207,9 +207,9 @@ public partial class CommandTree
     {
         if (ctx.Match("name", "rename", "changename"))
             await ctx.CheckSystem(target).Execute<SystemEdit>(SystemRename, m => m.Name(ctx, target));
-        else if (ctx.Match("tag"))
+        else if (ctx.Match("tag", "t"))
             await ctx.CheckSystem(target).Execute<SystemEdit>(SystemTag, m => m.Tag(ctx, target));
-        else if (ctx.Match("servertag"))
+        else if (ctx.Match("servertag", "st"))
             await ctx.CheckSystem(target).Execute<SystemEdit>(SystemServerTag, m => m.ServerTag(ctx, target));
         else if (ctx.Match("description", "desc", "bio"))
             await ctx.CheckSystem(target).Execute<SystemEdit>(SystemDesc, m => m.Description(ctx, target));

--- a/PluralKit.Bot/CommandMeta/CommandTree.cs
+++ b/PluralKit.Bot/CommandMeta/CommandTree.cs
@@ -35,7 +35,7 @@ public partial class CommandTree
             return ctx.Execute<ImportExport>(Import, m => m.Import(ctx));
         if (ctx.Match("export"))
             return ctx.Execute<ImportExport>(Export, m => m.Export(ctx));
-        if (ctx.Match("help"))
+        if (ctx.Match("help", "h"))
             if (ctx.Match("commands"))
                 return ctx.Reply("For the list of commands, see the website: <https://pluralkit.me/commands>");
             else if (ctx.Match("proxy"))
@@ -306,7 +306,7 @@ public partial class CommandTree
             await ctx.Execute<MemberEdit>(MemberServerName, m => m.ServerName(ctx, target));
         else if (ctx.Match("autoproxy", "ap"))
             await ctx.Execute<MemberEdit>(MemberAutoproxy, m => m.MemberAutoproxy(ctx, target));
-        else if (ctx.Match("keepproxy", "keeptags", "showtags"))
+        else if (ctx.Match("keepproxy", "keeptags", "showtags", "kp"))
             await ctx.Execute<MemberEdit>(MemberKeepProxy, m => m.KeepProxy(ctx, target));
         else if (ctx.Match("privacy"))
             await ctx.Execute<MemberEdit>(MemberPrivacy, m => m.Privacy(ctx, target, null));

--- a/PluralKit.Bot/CommandMeta/CommandTree.cs
+++ b/PluralKit.Bot/CommandMeta/CommandTree.cs
@@ -205,7 +205,7 @@ public partial class CommandTree
 
     private async Task HandleSystemCommandTargeted(Context ctx, PKSystem target)
     {
-        if (ctx.Match("name", "rename", "changename"))
+        if (ctx.Match("name", "rename", "changename", "rn"))
             await ctx.CheckSystem(target).Execute<SystemEdit>(SystemRename, m => m.Name(ctx, target));
         else if (ctx.Match("tag", "t"))
             await ctx.CheckSystem(target).Execute<SystemEdit>(SystemTag, m => m.Tag(ctx, target));
@@ -269,7 +269,7 @@ public partial class CommandTree
     private async Task HandleMemberCommandTargeted(Context ctx, PKMember target)
     {
         // Commands that have a member target (eg. pk;member <member> delete)
-        if (ctx.Match("rename", "name", "changename", "setname"))
+        if (ctx.Match("rename", "name", "changename", "setname", "rn"))
             await ctx.Execute<MemberEdit>(MemberRename, m => m.Name(ctx, target));
         else if (ctx.Match("description", "info", "bio", "text", "desc"))
             await ctx.Execute<MemberEdit>(MemberDesc, m => m.Description(ctx, target));
@@ -336,7 +336,7 @@ public partial class CommandTree
         else if (await ctx.MatchGroup() is { } target)
         {
             // Commands with group argument
-            if (ctx.Match("rename", "name", "changename", "setname"))
+            if (ctx.Match("rename", "name", "changename", "setname", "rn"))
                 await ctx.Execute<Groups>(GroupRename, g => g.RenameGroup(ctx, target));
             else if (ctx.Match("nick", "dn", "displayname", "nickname"))
                 await ctx.Execute<Groups>(GroupDisplayName, g => g.GroupDisplayName(ctx, target));

--- a/PluralKit.Bot/Commands/Autoproxy.cs
+++ b/PluralKit.Bot/Commands/Autoproxy.cs
@@ -18,9 +18,9 @@ public class Autoproxy
 
         if (ctx.Match("off", "stop", "cancel", "no", "disable", "remove"))
             await AutoproxyOff(ctx, settings);
-        else if (ctx.Match("latch", "last", "proxy", "stick", "sticky"))
+        else if (ctx.Match("latch", "last", "proxy", "stick", "sticky", "l"))
             await AutoproxyLatch(ctx, settings);
-        else if (ctx.Match("front", "fronter", "switch"))
+        else if (ctx.Match("front", "fronter", "switch", "f"))
             await AutoproxyFront(ctx, settings);
         else if (ctx.Match("member"))
             throw new PKSyntaxError("Member-mode autoproxy must target a specific member. Use the `pk;autoproxy <member>` command, where `member` is the name or ID of a member in your system.");


### PR DESCRIPTION
These are just the ones we could see in Notion as having already been suggested.

- `pk;h` -> `pk;help`
- `pk;s t` -> `pk;system tag`
- `pk;s st` -> `pk;system servertag`
- `pk;s rn` -> `pk;system rename`
- `pk;m rn` -> `pk;member rename`
- `pk;g rn` -> `pk;group rename`
- `pk;m <member> kp` -> `pk;member <member> keepproxy`
- `pk;ap l` -> `pk;autoproxy latch`
- `pk;ap f` -> `pk;autoproxy front`