### PR TITLE
feat: add `pk;reproxy`

### DIFF
--- a/PluralKit.Bot/CommandMeta/CommandHelp.cs
+++ b/PluralKit.Bot/CommandMeta/CommandHelp.cs
@@ -86,6 +86,7 @@ public partial class CommandTree
     public static Command Explain = new Command("explain", "explain", "Explains the basics of systems and proxying");
     public static Command Message = new Command("message", "message <id|link> [delete|author]", "Looks up a proxied message");
     public static Command MessageEdit = new Command("edit", "edit [link] <text>", "Edit a previously proxied message");
+    public static Command MessageReproxy = new Command("reproxy", "reproxy [link] <member>", "Reproxy a previously proxied message using a different member");
     public static Command ProxyCheck = new Command("debug proxy", "debug proxy [link|reply]", "Checks why your message has not been proxied");
     public static Command LogChannel = new Command("log channel", "log channel <channel>", "Designates a channel to post proxied messages to");
     public static Command LogChannelClear = new Command("log channel", "log channel -clear", "Clears the currently set log channel");

--- a/PluralKit.Bot/CommandMeta/CommandTree.cs
+++ b/PluralKit.Bot/CommandMeta/CommandTree.cs
@@ -48,6 +48,8 @@ public partial class CommandTree
             return ctx.Execute<ProxiedMessage>(Message, m => m.GetMessage(ctx));
         if (ctx.Match("edit", "e"))
             return ctx.Execute<ProxiedMessage>(MessageEdit, m => m.EditMessage(ctx));
+        if (ctx.Match("reproxy", "rp"))
+            return ctx.Execute<ProxiedMessage>(MessageReproxy, m => m.ReproxyMessage(ctx));
         if (ctx.Match("log"))
             if (ctx.Match("channel"))
                 return ctx.Execute<ServerConfig>(LogChannel, m => m.SetLogChannel(ctx));

--- a/PluralKit.Bot/Commands/Message.cs
+++ b/PluralKit.Bot/Commands/Message.cs
@@ -62,8 +62,7 @@ public class ProxiedMessage
             throw new PKError("The message is too old to be reproxied.");
 
         // Get target member ID
-        var target = await ctx.MatchMember();
-        var previousPtr = ctx.Parameters._ptr;
+        var target = await ctx.MatchMember(restrictToSystem: ctx.System.Id);
         if (target == null)
             throw new PKError("Could not find a member to reproxy the message with.");
 

--- a/PluralKit.Bot/Commands/Message.cs
+++ b/PluralKit.Bot/Commands/Message.cs
@@ -182,7 +182,7 @@ public class ProxiedMessage
         }
 
         var msgTimestamp = DiscordUtils.SnowflakeToInstant(msg.Message.Mid);
-        if (SystemClock.Instance.GetCurrentInstant() - msgTimestamp > timeout)
+        if (isReproxy && SystemClock.Instance.GetCurrentInstant() - msgTimestamp > timeout)
             throw new PKError($"The message is too old to be {editTypeAction}.");
 
         return msg;

--- a/PluralKit.Bot/Commands/Message.cs
+++ b/PluralKit.Bot/Commands/Message.cs
@@ -56,6 +56,11 @@ public class ProxiedMessage
         if (ctx.System.Id != msg.System?.Id)
             throw new PKError("Can't reproxy a message sent by a different system.");
 
+        // Bail if the message is more than 2 minutes old
+        var msgTimestamp = Instant.FromUnixTimeMilliseconds((long)(msg.Message.Mid >> 22) + 1420070400000);
+        if (msgTimestamp.Plus(Duration.FromSeconds(60 * 2)) < SystemClock.Instance.GetCurrentInstant())
+            throw new PKError("The message is too old to be reproxied.");
+
         // Get target member ID
         var target = await ctx.MatchMember();
         var previousPtr = ctx.Parameters._ptr;

--- a/PluralKit.Bot/Commands/Message.cs
+++ b/PluralKit.Bot/Commands/Message.cs
@@ -13,6 +13,8 @@ using Myriad.Types;
 
 using NodaTime;
 
+using IMetrics = App.Metrics.IMetrics;
+
 using PluralKit.Core;
 
 namespace PluralKit.Bot;
@@ -21,8 +23,10 @@ public class ProxiedMessage
 {
     private static readonly Duration EditTimeout = Duration.FromMinutes(10);
 
-    // private readonly IDiscordCache _cache;
+    private readonly IDiscordCache _cache;
+    private readonly ModelRepository _repo;
     private readonly IClock _clock;
+    private readonly IMetrics _metrics;
 
     private readonly EmbedService _embeds;
     private readonly LogChannelService _logChannel;
@@ -30,15 +34,87 @@ public class ProxiedMessage
     private readonly WebhookExecutorService _webhookExecutor;
 
     public ProxiedMessage(EmbedService embeds, IClock clock,
-                          DiscordApiClient rest,
+                          DiscordApiClient rest, IMetrics metrics, ModelRepository repo,
                           WebhookExecutorService webhookExecutor, LogChannelService logChannel, IDiscordCache cache)
     {
         _embeds = embeds;
         _clock = clock;
         _rest = rest;
         _webhookExecutor = webhookExecutor;
+        _repo = repo;
         _logChannel = logChannel;
-        // _cache = cache;
+        _cache = cache;
+        _metrics = metrics;
+    }
+
+    public async Task ReproxyMessage(Context ctx)
+    {
+        var msg = await GetMessageToEdit(ctx);
+
+        if (ctx.System.Id != msg.System?.Id)
+            throw new PKError("Can't reproxy a message sent by a different system.");
+
+        var originalMsg = await _rest.GetMessageOrNull(msg.Message.Channel, msg.Message.Mid);
+        if (originalMsg == null)
+            throw new PKError("Could not reproxy message.");
+
+        // Get target member ID
+        var target = await ctx.MatchMember();
+        var previousPtr = ctx.Parameters._ptr;
+
+        // Fetch members and get the ProxyMember for `target`
+        List <ProxyMember> members;
+        using (_metrics.Measure.Timer.Time(BotMetrics.ProxyMembersQueryTime))
+            members = (await _repo.GetProxyMembers(ctx.Author.Id, msg.Message.Guild!.Value)).ToList();
+        var match = members.Find(x => x.Id == target.Id);
+        if (match == null)
+            throw new PKError("Could not reproxy message.");
+
+        // Get a MessageContext for the original message
+        MessageContext? msgCtx =
+               await _repo.GetMessageContext(msg.Message.Sender, msg.Message.Guild!.Value, originalMsg.ChannelId);
+
+        try
+        {
+            var messageChannel = await _cache.GetChannel(originalMsg.ChannelId);
+            var rootChannel = await _cache.GetRootChannel(originalMsg.ChannelId);
+            var threadId = messageChannel.IsThread() ? messageChannel.Id : (ulong?)null;
+            var guild = await _cache.GetGuild(msg.Message.Guild!.Value);
+
+            var senderPermissions = PermissionExtensions.PermissionsFor(guild, rootChannel, msg.Message.Sender, null);
+            var allowEveryone = senderPermissions.HasFlag(PermissionSet.MentionEveryone);
+            var allowEmbeds = senderPermissions.HasFlag(PermissionSet.EmbedLinks);
+
+            var proxyMessage = await _webhookExecutor.ExecuteWebhook(new ProxyRequest
+            {
+                GuildId = msg.Message.Guild!.Value,
+                ChannelId = rootChannel.Id,
+                ThreadId = threadId,
+                Name = match.ProxyName(msgCtx),
+                AvatarUrl = AvatarUtils.TryRewriteCdnUrl(match.ProxyAvatar(msgCtx)),
+                Content = originalMsg.Content!,
+                Attachments = originalMsg.Attachments!,
+                FileSizeLimit = guild.FileSizeLimit(),
+                Embeds = originalMsg.Embeds!.ToArray(),
+                Stickers = originalMsg.StickerItems!,
+                AllowEveryone = allowEveryone
+            });
+
+            if (ctx.Guild == null)
+                await _rest.CreateReaction(ctx.Channel.Id, ctx.Message.Id, new Emoji { Name = Emojis.Success });
+
+            if ((await ctx.BotPermissions).HasFlag(PermissionSet.ManageMessages))
+                await _rest.DeleteMessage(ctx.Channel.Id, ctx.Message.Id);
+
+            await _rest.DeleteMessage(originalMsg.ChannelId!, originalMsg.Id!);
+
+            await _logChannel.LogMessage(ctx.MessageContext, msg.Message, ctx.Message, proxyMessage,
+                originalMsg!.Content!);
+        }
+        catch (NotFoundException)
+        {
+            throw new PKError("Could not reproxy message.");
+        }
     }
 
     public async Task EditMessage(Context ctx)

--- a/PluralKit.Bot/Commands/Message.cs
+++ b/PluralKit.Bot/Commands/Message.cs
@@ -13,7 +13,7 @@ using Myriad.Types;
 
 using NodaTime;
 
-using IMetrics = App.Metrics.IMetrics;
+using App.Metrics;
 
 using PluralKit.Core;
 
@@ -25,7 +25,6 @@ public class ProxiedMessage
 
     // private readonly IDiscordCache _cache;
     private readonly ModelRepository _repo;
-    private readonly IClock _clock;
     private readonly IMetrics _metrics;
 
     private readonly EmbedService _embeds;
@@ -34,12 +33,11 @@ public class ProxiedMessage
     private readonly WebhookExecutorService _webhookExecutor;
     private readonly ProxyService _proxy;
 
-    public ProxiedMessage(EmbedService embeds, IClock clock,
+    public ProxiedMessage(EmbedService embeds,
                           DiscordApiClient rest, IMetrics metrics, ModelRepository repo, ProxyService proxy,
                           WebhookExecutorService webhookExecutor, LogChannelService logChannel, IDiscordCache cache)
     {
         _embeds = embeds;
-        _clock = clock;
         _rest = rest;
         _webhookExecutor = webhookExecutor;
         _repo = repo;
@@ -194,7 +192,7 @@ public class ProxiedMessage
             return null;
 
         var timestamp = DiscordUtils.SnowflakeToInstant(lastMessage.Mid);
-        if (_clock.GetCurrentInstant() - timestamp > EditTimeout)
+        if (SystemClock.Instance.GetCurrentInstant() - timestamp > EditTimeout)
             return null;
 
         return lastMessage;

--- a/PluralKit.Bot/Commands/Message.cs
+++ b/PluralKit.Bot/Commands/Message.cs
@@ -179,7 +179,7 @@ public class ProxiedMessage
         }
 
         var msgTimestamp = DiscordUtils.SnowflakeToInstant(msg.Message.Mid);
-        if (_clock.GetCurrentInstant() - msgTimestamp > timeout)
+        if (SystemClock.Instance.GetCurrentInstant() - msgTimestamp > timeout)
             throw new PKError("The message is too old to be edited.");
 
         return msg;

--- a/PluralKit.Bot/Proxy/ProxyService.cs
+++ b/PluralKit.Bot/Proxy/ProxyService.cs
@@ -233,7 +233,7 @@ public class ProxyService
             AllowEveryone = allowEveryone
         });
 
-        var sentMessage = await HandleProxyExecutedActions(ctx, autoproxySettings, trigger, proxyMessage, match);
+        var sentMessage = await HandleProxyExecutedActions(ctx, autoproxySettings, trigger, proxyMessage, match, deletePrevious: false);
         await _rest.DeleteMessage(originalMsg.ChannelId!, originalMsg.Id!);
         await _logChannel.LogMessage(ctx, sentMessage, trigger, proxyMessage, originalMsg.Content!);
     }
@@ -358,7 +358,8 @@ public class ProxyService
         => message.Content.StartsWith(@"\\") || message.Content.StartsWith("\\\u200b\\");
 
     private async Task<PKMessage> HandleProxyExecutedActions(MessageContext ctx, AutoproxySettings autoproxySettings,
-                                                             Message triggerMessage, Message proxyMessage, ProxyMatch match)
+                                                             Message triggerMessage, Message proxyMessage, ProxyMatch match,
+                                                             bool deletePrevious = true)
     {
         var sentMessage = new PKMessage
         {
@@ -388,6 +389,9 @@ public class ProxyService
 
         async Task DeleteProxyTriggerMessage()
         {
+            if (!deletePrevious)
+                return;
+
             // Wait a second or so before deleting the original message
             await Task.Delay(MessageDeletionDelay);
             try

--- a/PluralKit.Bot/Proxy/ProxyService.cs
+++ b/PluralKit.Bot/Proxy/ProxyService.cs
@@ -238,7 +238,7 @@ public class ProxyService
         });
 
         var autoproxySettings = await _repo.GetAutoproxySettings(ctx.SystemId.Value, msg.Guild!.Value, null);
-        var sentMessage = await HandleProxyExecutedActions(ctx, autoproxySettings, trigger, proxyMessage, match, deletePrevious: false);
+        await HandleProxyExecutedActions(ctx, autoproxySettings, trigger, proxyMessage, match, deletePrevious: false);
         await _rest.DeleteMessage(originalMsg.ChannelId!, originalMsg.Id!);
     }
 
@@ -361,9 +361,9 @@ public class ProxyService
     public static bool IsUnlatch(Message message)
         => message.Content.StartsWith(@"\\") || message.Content.StartsWith("\\\u200b\\");
 
-    private async Task<PKMessage> HandleProxyExecutedActions(MessageContext ctx, AutoproxySettings autoproxySettings,
-                                                             Message triggerMessage, Message proxyMessage, ProxyMatch match,
-                                                             bool deletePrevious = true)
+    private async Task HandleProxyExecutedActions(MessageContext ctx, AutoproxySettings autoproxySettings,
+                                                  Message triggerMessage, Message proxyMessage, ProxyMatch match,
+                                                  bool deletePrevious = true)
     {
         var sentMessage = new PKMessage
         {
@@ -420,8 +420,6 @@ public class ProxyService
             SaveLatchAutoproxy(),
             DispatchWebhook()
         );
-
-        return sentMessage;
     }
 
     private async Task HandleTriggerAlreadyDeleted(Message proxyMessage)

--- a/PluralKit.Bot/Proxy/ProxyService.cs
+++ b/PluralKit.Bot/Proxy/ProxyService.cs
@@ -240,7 +240,6 @@ public class ProxyService
         var autoproxySettings = await _repo.GetAutoproxySettings(ctx.SystemId.Value, msg.Guild!.Value, null);
         var sentMessage = await HandleProxyExecutedActions(ctx, autoproxySettings, trigger, proxyMessage, match, deletePrevious: false);
         await _rest.DeleteMessage(originalMsg.ChannelId!, originalMsg.Id!);
-        await _logChannel.LogMessage(ctx, sentMessage, trigger, proxyMessage, originalMsg.Content!);
     }
 
     private async Task<(string?, string?)> FetchReferencedMessageAuthorInfo(Message trigger, Message referenced)

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -134,6 +134,7 @@ Some arguments indicate the use of specific Discord features. These include:
 - `pk;debug permissions [server id]` - [Checks the given server's permission setup](/staff/permissions/#permission-checker-command) to check if it's compatible with PluralKit.
 - `pk;debug proxying <message link|reply>` - Checks why your message has not been proxied.
 - `pk;edit [message link|reply] <new content>` - Edits a proxied message. Without an explicit message target, will target the last message proxied by your system in the current channel. **Does not support message IDs!**
+- `pk;reproxy [message link|reply] <member name|ID>` - Reproxies a message using a different member. Without an explicit message target, will target the last message proxied by your system in the current channel.
 - `pk;link <account>` - Links your system to a different account.
 - `pk;unlink [account]` - Unlinks an account from your system.
 


### PR DESCRIPTION
Adds `pk;reproxy` (`pk;rp`) to reproxy the last sent message, or a linked message (in the same way `pk;edit` does) using the given member, which can be specified as a member name or ID.

This is probably not the best way to do this, very happy to make any changes. 