### PR TITLE
chore: update nuget Grpc.Tools to 2.47.0

### DIFF
--- a/Myriad/Myriad.csproj
+++ b/Myriad/Myriad.csproj
@@ -23,7 +23,7 @@
     <ItemGroup>
         <PackageReference Include="Google.Protobuf" Version="3.13.0"/>
         <PackageReference Include="Grpc.Net.ClientFactory" Version="2.32.0" />
-        <PackageReference Include="Grpc.Tools" Version="2.37.0" PrivateAssets="All"/>
+        <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="all" />
         <PackageReference Include="Polly" Version="7.2.1"/>
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1"/>
         <PackageReference Include="Serilog" Version="2.10.0"/>

--- a/Myriad/packages.lock.json
+++ b/Myriad/packages.lock.json
@@ -24,9 +24,9 @@
       },
       "Grpc.Tools": {
         "type": "Direct",
-        "requested": "[2.37.0, )",
-        "resolved": "2.37.0",
-        "contentHash": "cud/urkbw3QoQ8+kNeCy2YI0sHrh7td/1cZkVbH6hDLIXX7zzmJbV/KjYSiqiYtflQf+S5mJPLzDQWScN/QdDg=="
+        "requested": "[2.47.0, )",
+        "resolved": "2.47.0",
+        "contentHash": "nInNoLfT/zR7+0VNIC4Lu5nF8azjTz3KwHB1ckwsYUxvof4uSxIt/LlCKb/NH7GPfXfdvqDDinguPpP5t55nuA=="
       },
       "Polly": {
         "type": "Direct",

--- a/PluralKit.API/PluralKit.API.csproj
+++ b/PluralKit.API/PluralKit.API.csproj
@@ -32,7 +32,7 @@
         <PackageReference Include="App.Metrics.Prometheus" Version="4.3.0" />
         <PackageReference Include="App.Metrics.Reporting.Console" Version="4.3.0" />
         <PackageReference Include="Google.Protobuf" Version="3.13.0" />
-        <PackageReference Include="Grpc.Tools" Version="2.37.0" PrivateAssets="All" />
+        <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.2.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.2.0" />

--- a/PluralKit.API/packages.lock.json
+++ b/PluralKit.API/packages.lock.json
@@ -53,9 +53,9 @@
       },
       "Grpc.Tools": {
         "type": "Direct",
-        "requested": "[2.37.0, )",
-        "resolved": "2.37.0",
-        "contentHash": "cud/urkbw3QoQ8+kNeCy2YI0sHrh7td/1cZkVbH6hDLIXX7zzmJbV/KjYSiqiYtflQf+S5mJPLzDQWScN/QdDg=="
+        "requested": "[2.47.0, )",
+        "resolved": "2.47.0",
+        "contentHash": "nInNoLfT/zR7+0VNIC4Lu5nF8azjTz3KwHB1ckwsYUxvof4uSxIt/LlCKb/NH7GPfXfdvqDDinguPpP5t55nuA=="
       },
       "Microsoft.AspNetCore.Mvc.NewtonsoftJson": {
         "type": "Direct",

--- a/PluralKit.Bot/PluralKit.Bot.csproj
+++ b/PluralKit.Bot/PluralKit.Bot.csproj
@@ -24,7 +24,7 @@
     <ItemGroup>
         <PackageReference Include="Google.Protobuf" Version="3.13.0"/>
         <PackageReference Include="Grpc.Net.ClientFactory" Version="2.32.0" />
-        <PackageReference Include="Grpc.Tools" Version="2.37.0" PrivateAssets="All"/>
+        <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="all" />
         <PackageReference Include="Humanizer.Core" Version="2.8.26"/>
         <PackageReference Include="Sentry" Version="3.11.1"/>
         <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2"/>

--- a/PluralKit.Bot/packages.lock.json
+++ b/PluralKit.Bot/packages.lock.json
@@ -24,9 +24,9 @@
       },
       "Grpc.Tools": {
         "type": "Direct",
-        "requested": "[2.37.0, )",
-        "resolved": "2.37.0",
-        "contentHash": "cud/urkbw3QoQ8+kNeCy2YI0sHrh7td/1cZkVbH6hDLIXX7zzmJbV/KjYSiqiYtflQf+S5mJPLzDQWScN/QdDg=="
+        "requested": "[2.47.0, )",
+        "resolved": "2.47.0",
+        "contentHash": "nInNoLfT/zR7+0VNIC4Lu5nF8azjTz3KwHB1ckwsYUxvof4uSxIt/LlCKb/NH7GPfXfdvqDDinguPpP5t55nuA=="
       },
       "Humanizer.Core": {
         "type": "Direct",


### PR DESCRIPTION
The version previously used (2.37.0) is completely broken on aarch64 Linux, so building the bot just didn't work on that platform (which, uh, happens to be what we use as our main development machine now…)