### PR TITLE
Small fix for clarifying purposes.

### DIFF
--- a/PluralKit.Bot/Commands/Help.cs
+++ b/PluralKit.Bot/Commands/Help.cs
@@ -29,8 +29,8 @@ public class Help
                 ),
                 new
                 (
-                    "Why are people's names saying [BOT] next to them?",
-                    "These people are not actually bots, this is just a Discord limitation. See [the documentation](https://pluralkit.me/guide#proxying) for an in-depth explanation."
+                    "Why are people's names saying [APP] next to them?",
+                    "These people aren't apps or bots, this is just a Discord limitation. See [the documentation](https://pluralkit.me/guide#proxying) for an in-depth explanation."
                 ),
             }
         },


### PR DESCRIPTION
Hello!

I frequent servers using PluralKit for systems and noticed that Discord has rolled out a replacement to the ``BOT`` tag, an ``APP`` tag.

This just makes the tiny change to the help command that adds that clarification while retaining the original meaning.