### PR TITLE
fix: Normalize alias for the random and remove commands

### DIFF
--- a/PluralKit.Bot/CommandMeta/CommandTree.cs
+++ b/PluralKit.Bot/CommandMeta/CommandTree.cs
@@ -383,7 +383,7 @@ public partial class CommandTree
             else if (ctx.Match("add", "a"))
                 await ctx.Execute<GroupMember>(GroupAdd,
                     g => g.AddRemoveMembers(ctx, target, Groups.AddRemoveOperation.Add));
-            else if (ctx.Match("remove", "rem")
+            else if (ctx.Match("remove", "rem"))
                 await ctx.Execute<GroupMember>(GroupRemove,
                     g => g.AddRemoveMembers(ctx, target, Groups.AddRemoveOperation.Remove));
             else if (ctx.Match("members", "list", "ms", "l", "ls"))


### PR DESCRIPTION
Based on a [conversation in the Discord](https://discord.com/channels/466707357099884544/468821582794588160/1298713837050265722), this is a pre-emptive change to normalize the "r" alias between the random and remove commands.

`r` has traditionally been given to the `random` command, as is true in the `pk;s random` iteration. But it was also given to `pk;group <group> remove`, which had not normally been a problem until #663 added the ability to remove all members using the `-all` flag. This has caused a decent amount of confusion and made apparent the alias is inconsistent within group commands.

While #687 should help with the accidental removals, this PR puts the aliases back where they "should" be, matching `pk;s r` as it's easily the most used variant of the command.

~ Frankie!