### PR TITLE
Add pk;rp to Command Shorthand list

### DIFF
--- a/docs/content/tips-and-tricks.md
+++ b/docs/content/tips-and-tricks.md
@@ -27,6 +27,7 @@ PluralKit has a couple of useful command shorthands to reduce the typing:
 |pk;switch|pk;sw|
 |pk;message|pk;msg|
 |pk;autoproxy|pk;ap|
+|pk;reproxy|pk;rp|
 |pk;edit|pk;e|
 |pk;edit -regex|pk;x|
 


### PR DESCRIPTION
In the command shorthand list, adds an entry for `pk;rp` showing that it is shorthand  for `pk;reproxy`.

I added it between `pk;ap` (for `pk;autoproxy`) and `pk;e` (for `pk;edit`) because it would be next to `pk;autoproxy` which has more of a similarity in naming scheme; I'm open to the idea it should be placed after the two `pk;edit` entries instead due to the similarity in functionality.