### PR TITLE
fix(docs): mark system model's `created` as non-null

### DIFF
--- a/docs/content/api/models.md
+++ b/docs/content/api/models.md
@@ -31,7 +31,7 @@ The PluralKit Discord bot can be configured to display short IDs in uppercase, o
 |avatar_url|?string|256-character limit, must be a publicly-accessible URL|
 |banner|?string|256-character limit, must be a publicly-accessible URL|
 |color|?string|6-character hex code, no `#` at the beginning|
-|created|?datetime||
+|created|datetime||
 |privacy|?system privacy object||
 
 * System privacy keys: `description_privacy`, `pronoun_privacy`, `member_list_privacy`, `group_list_privacy`, `front_privacy`, `front_history_privacy`


### PR DESCRIPTION
Based on my understanding of [the code](https://github.com/PluralKit/PluralKit/blob/fdfa2baaef12b66e428a6d432fefe3616a7dd646/PluralKit.Core/Models/PKSystem.cs#L77)

a system's `created` property would never be null, so mark it as non-null in the api docs