### PR TITLE
fix(docs): `id_padding_format` uses `off` instead of `none` in the API

### DIFF
--- a/docs/content/api/models.md
+++ b/docs/content/api/models.md
@@ -136,7 +136,7 @@ The PluralKit Discord bot can be configured to display short IDs in uppercase, o
 
 |key|description|
 |---|---|
-|none|do not pad 5-character ids|
+|off|do not pad 5-character ids|
 |left|add a padding space to the left of 5-character ids in lists|
 |right|add a padding space to the right of 5-character ids in lists|
 


### PR DESCRIPTION
this gets changed from `none` to `off` here

https://github.com/PluralKit/PluralKit/blob/47c59902181b6f81b046f9c471780efd85fd708f/PluralKit.Core/Models/SystemConfig.cs#L71-L75